### PR TITLE
Make passwords optional

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -43,7 +43,7 @@ hana:
         root_password:
           $name: Machine root password
           $type: password
-          $optional: false
+          $optional: true
         use_config_file:
           $name: Use configuration file
           $type: boolean

--- a/form.yml
+++ b/form.yml
@@ -56,10 +56,12 @@ hana:
           $name: Sap admin password
           $visibleIf: .use_config_file == false
           $type: password
+          $optional: true
         system_user_password:
           $name: Sap user password
           $visibleIf: .use_config_file == false
           $type: password
+          $optional: true
         extra_parameters:
           $name: Installation extra options
           $optional: true


### PR DESCRIPTION
Make the root & SAP admin/user passwords optional.

This is needed for secure cloud configurations where SSH public keys should be used.