### PR TITLE
Feature/pre configured packages and other minor changes

### DIFF
--- a/hana/defaults.yaml
+++ b/hana/defaults.yaml
@@ -1,4 +1,5 @@
 hana:
+  install_packages: true
   nodes:
     - host: 'hana01'
       sid: 'prd'

--- a/hana/init.sls
+++ b/hana/init.sls
@@ -1,5 +1,7 @@
+{% from "hana/map.jinja" import cluster with context %}
+
 include:
-  - hana.common
+  - hana.packages
   - hana.pre_validation
   - hana.install
   - hana.enable_primary

--- a/hana/init.sls
+++ b/hana/init.sls
@@ -1,7 +1,9 @@
-{% from "hana/map.jinja" import cluster with context %}
+{% from "hana/map.jinja" import hana with context %}
 
 include:
+{% if hana.install_packages is sameas true %}
   - hana.packages
+{% endif %}
   - hana.pre_validation
   - hana.install
   - hana.enable_primary

--- a/hana/packages.sls
+++ b/hana/packages.sls
@@ -15,13 +15,10 @@ patterns-sap-hana:
 install_required_packages:
   pkg.installed:
     - pkgs:
-      - numactl
+      - libnuma1
       - libltdl7
 
 {% endif %}
 
 python-shaptools:
-  pkg.installed:
-    - fromrepo: saphana
-    - require:
-      - add-saphana-repo
+  pkg.installed

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,8 @@
 hana:
+  # optional: Install required packages to install SAP HANA (true by default)
+  # If set to false, this packages must be installed before the formula 
+  # execution manually
+  # install_packages: true
   nodes:
     - host: 'hana01'
       sid: 'prd'


### PR DESCRIPTION
This pull request includes a feature to allow pre-configured packages as we are doing in habootstrap-formula ([PR](https://github.com/SUSE/habootstrap-formula/pull/5))

It includes some other minor changes:
* Rename common.sls to packages.sls (to keep the same logical as used in habootstrap-formula)
* Replace numactl by libnuma1
* Remove add-saphana-repo because it doesn't exist anymore (forgotten in the last push I guess)