### PR TITLE
Install the Salt files on the salt-shared location from 15-SP1.

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,8 +1,19 @@
 -------------------------------------------------------------------
+Fri May 21 12:37:43 UTC 2019 - Diego Vinicius Akechi <dakechi@suse.com>
+
+- Version bump 0.1.1
+  * Include the salt-formulas-configuration dependency on
+    SLE/Leap 15-SP1 and higher. This package configures the shared salt
+    formulas location (/usr/share/salt-formulas) to be used by SUMA 4.0
+    or salt in standalone mode.
+  * Drops the saphanabootstrap-formula-suma package, as the forms metadata
+    will be available only on SUMA 4.0 using the shared location.
+
+-------------------------------------------------------------------
 Thu May 16 08:52:06 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Update formula to work with the latest shaptools code. In this version
-  the secondary node registration is managed completely in shaptools 
+  the secondary node registration is managed completely in shaptools
 
 -------------------------------------------------------------------
 Thu Apr 25 12:06:43 UTC 2019 - Diego Vinicius Akechi <dakechi@suse.com>
@@ -13,26 +24,26 @@ Thu Apr 25 12:06:43 UTC 2019 - Diego Vinicius Akechi <dakechi@suse.com>
 Mon Mar 18 08:50:43 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Update primary available checking to execute this action before
-  trying to copy the SSFS files from primary node 
+  trying to copy the SSFS files from primary node
 - Add configurable timeout to wait to the primary node
 
 -------------------------------------------------------------------
 Tue Mar 12 07:52:37 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Fix OS release comparison to use integer type in order to choose
-  installable python version 
+  installable python version
 
 -------------------------------------------------------------------
 Fri Mar  8 13:47:41 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
-- Improve shaptools installation python version management 
+- Improve shaptools installation python version management
 
 -------------------------------------------------------------------
 Mon Mar  4 15:30:24 UTC 2019 - xarbulu@suse.com
 
 - Improved the use of keystore access. When the key_name is informed,
   the user_name/user_password is not needed.
-    
+
 -------------------------------------------------------------------
 Wed Feb 25 10:15:35 UTC 2019 - dakechi@suse.com
 
@@ -43,9 +54,9 @@ Wed Feb 25 10:15:35 UTC 2019 - dakechi@suse.com
 -------------------------------------------------------------------
 Wed Feb 20 08:18:35 UTC 2019 - xarbulu@suse.com
 
-- Add templates folder with RA configuration templates 
+- Add templates folder with RA configuration templates
 
 -------------------------------------------------------------------
 Thu Dec 20 08:33:10 UTC 2018 - xarbulu@suse.com
 
-- First version of the SAP HANA deployment formula 
+- First version of the SAP HANA deployment formula

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Fri May 21 12:37:43 UTC 2019 - Diego Vinicius Akechi <dakechi@suse.com>
 
-- Version bump 0.1.1
+- Version bump 0.2.0
   * Include the salt-formulas-configuration dependency on
     SLE/Leap 15-SP1 and higher. This package configures the shared salt
     formulas location (/usr/share/salt-formulas) to be used by SUMA 4.0

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.1.1
+Version:        0.2.0
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package saphanabootstrap-formula
 #
-# Copyright (c) 2018 SUSE LLC, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,40 +12,39 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
 
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.1.0
-Release:        1
+Version:        0.1.1
+Release:        0
 Summary:        SAP HANA platform deployment formula
-
 License:        Apache-2.0
+
 Url:            https://github.com/SUSE/%{name}
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Requires:       salt-shaptools
 Requires:       habootstrap-formula
+Requires:       salt-shaptools
+
+# On SLE/Leap 15-SP1 and TW requires the new salt-formula configuration location.
+%if ! (0%{?sle_version:1} && 0%{?sle_version} < 150100)
+Requires:       salt-formulas-configuration
+%endif
 
 %define fname hana
-%define fdir  %{_datadir}/susemanager/formulas
+%define fdir  %{_datadir}/salt-formulas
 %define ftemplates templates
 
 %description
-SAP HANA deployment salt formula
-
-# package to deploy on SUMA specific path.
-%package suma
-Summary:        SAP HANA platform deployment formula (SUMA specific)
-Requires:       salt-shaptools
-Requires:       habootstrap-formula-suma
-
-%description suma
-SAP HANA deployment salt formula (SUMA specific)
+SAP HANA deployment salt formula. This formula is capable to install
+SAP HANA nodes, enable system replication and configure SLE-HA cluster
+with the SAPHanaSR resource agent, using standalone salt or via SUSE Manager
+formulas with forms, available on SUSE Manager 4.0.
 
 %prep
 %setup -q
@@ -53,12 +52,17 @@ SAP HANA deployment salt formula (SUMA specific)
 %build
 
 %install
-pwd
+
+# before SUMA 4.0/15-SP1, install on the standard Salt Location.
+%if 0%{?sle_version:1} && 0%{?sle_version} < 150100
+
 mkdir -p %{buildroot}/srv/salt/
 cp -R %{fname} %{buildroot}/srv/salt/
 cp -R %{ftemplates} %{buildroot}/srv/salt/%{fname}/
 
-# SUMA Specific
+%else
+
+# On SUMA 4.0/15-SP1, a single shared directory will be used.
 mkdir -p %{buildroot}%{fdir}/states/%{fname}
 mkdir -p %{buildroot}%{fdir}/metadata/%{fname}
 cp -R %{fname} %{buildroot}%{fdir}/states
@@ -69,31 +73,24 @@ then
   cp -R metadata.yml %{buildroot}%{fdir}/metadata/%{fname}
 fi
 
+%endif
 
+%if 0%{?sle_version:1} && 0%{?sle_version} < 150100
 %files
 %defattr(-,root,root,-)
-# %license macro is not available on older releases
-%if 0%{?sle_version} <= 120300
-%doc LICENSE
-%else
 %license LICENSE
-%endif
 %doc README.md
 /srv/salt/%{fname}
 /srv/salt/%{fname}/%{ftemplates}
 
 %dir %attr(0755, root, salt) /srv/salt
 
-%files suma
-%defattr(-,root,root,-)
-# %license macro is not available on older releases
-%if 0%{?sle_version} <= 120300
-%doc LICENSE
 %else
+
+%files
+%defattr(-,root,root,-)
 %license LICENSE
-%endif
 %doc README.md
-%dir %{_datadir}/susemanager
 %dir %{fdir}
 %dir %{fdir}/states
 %dir %{fdir}/metadata
@@ -101,9 +98,10 @@ fi
 %{fdir}/states/%{fname}/%{ftemplates}
 %{fdir}/metadata/%{fname}
 
-%dir %attr(0755, root, salt) %{_datadir}/susemanager
 %dir %attr(0755, root, salt) %{fdir}
 %dir %attr(0755, root, salt) %{fdir}/states
 %dir %attr(0755, root, salt) %{fdir}/metadata
+
+%endif
 
 %changelog


### PR DESCRIPTION
Version bump 0.1.1
  * Include the salt-formulas-configuration dependency on
    SLE/Leap 15-SP1 and higher. This package configures the shared salt
    formulas location (/usr/share/salt-formulas) to be used by SUMA 4.0
    or salt in standalone mode.
  * Drops the saphanabootstrap-formula-suma package, as the forms metadata
    will be available only on SUMA 4.0 using the shared location.