### PR TITLE
Add condition to license macro

### DIFF
--- a/hana/packages.sls
+++ b/hana/packages.sls
@@ -25,8 +25,9 @@ install_required_packages:
 
 # Install shaptools depending on the os and python version
 {% if grains['pythonversion'][0] == 2 %}
-python2-shaptools:
+python-shaptools:
 {% else %}
 python3-shaptools:
 {% endif %}
-  pkg.installed
+  pkg.installed:
+    - resolve_capabilities: true

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -78,8 +78,12 @@ fi
 %if 0%{?sle_version:1} && 0%{?sle_version} < 150100
 %files
 %defattr(-,root,root,-)
-%license LICENSE
+%if 0%{?sle_version} < 120300
+%doc README.md LICENSE
+%else
 %doc README.md
+%license LICENSE
+%endif
 /srv/salt/%{fname}
 /srv/salt/%{fname}/%{ftemplates}
 
@@ -89,8 +93,8 @@ fi
 
 %files
 %defattr(-,root,root,-)
-%license LICENSE
 %doc README.md
+%license LICENSE
 %dir %{fdir}
 %dir %{fdir}/states
 %dir %{fdir}/metadata


### PR DESCRIPTION
Besides the `license` macro, an issue with the python-shaptools package name has been fixed (to install the package correctly in python-shaptools and python2-shaptools cases)