### PR TITLE
[WIP] Fix for srTakeover_hook

### DIFF
--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -32,7 +32,7 @@ setup_srHook_directory:
 install_srTakeover_hook:
     file.managed:
       - source: salt://hana/templates/srTakeover_hook.j2
-      - name: /hana/shared/srHook/sr-Takeover.py
+      - name: /hana/shared/srHook/srTakeover.py
       - user: {{ node.sid.lower() }}adm
       - group: sapsys
       - template: jinja
@@ -51,6 +51,20 @@ install_hana_python_packages:
       - require:
         - reduce_memory_resources_{{ node.host+node.sid }}
         - setup_srHook_directory
+
+configure_ha_dr_provider_srTakeover:
+    file.append:
+      - name:  /hana/shared/{{ node.sid }}/global/hdb/custom/config/global.ini
+      - text: |
+          [ha_dr_provider_srTakeover]
+          provider = srTakeover
+          path = /hana/shared/srHook
+          execution_order = 1
+      - require:
+        - reduce_memory_resources_{{ node.host+node.sid }}
+        - setup_srHook_directory
+        - install_srTakeover_hook
+        - install_hana_python_packages
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -54,7 +54,7 @@ install_hana_python_packages:
 
 configure_ha_dr_provider_srTakeover:
     file.append:
-      - name:  /hana/shared/{{ node.sid }}/global/hdb/custom/config/global.ini
+      - name:  /hana/shared/{{ node.sid.upper() }}/global/hdb/custom/config/global.ini
       - text: |
           [ha_dr_provider_srTakeover]
           provider = srTakeover

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -47,6 +47,7 @@ install_hana_python_packages:
       - group: sapsys
       - enforce_toplevel: False
       - source: {{ grains['hana_inst_folder']~'/DATA_UNITS/HDB_CLIENT_LINUX_X86_64/client/PYDBAPI.TGZ' }}
+      - options: --strip=1 --wildcards 'hdbcli/*.py'
       - require:
         - reduce_memory_resources_{{ node.host+node.sid }}
         - setup_srHook_directory

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -46,7 +46,7 @@ install_hana_python_packages:
       - user: {{ node.sid.lower() }}adm
       - group: sapsys
       - enforce_toplevel: False
-      - source: {{ grains['hana_inst_folder']~'/DATA_UNITS/HDB_CLIENT_LINUX_X86_64/client/PYDBAPI.TGZ' }}
+      - source: {{ node.install.software_path~'/DATA_UNITS/HDB_CLIENT_LINUX_X86_64/client/PYDBAPI.TGZ' }}
       - options: --strip=1 --wildcards 'hdbcli/*.py'
       - require:
         - reduce_memory_resources_{{ node.host+node.sid }}


### PR DESCRIPTION
Updates to the srTakeover_hook
- Fixed the tarball extraction path for srHook related HANA py files
- Added the [ha_dr_provider_srTakeover] section to global.ini file 
for the hook to undo changes after takeover

Tested in local HANA environment, i need to test it with terraform deployment as well 
- Check that after takeover is triggered in cluster and when HANA on node02 become primary, the ini file changes(related to cost-optimized) are reverted/removed from global ini files:
/hana/shared/PRD/global/hdb/custom/config/global.ini