### PR TITLE
Feature/hanadb exporter

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -183,3 +183,27 @@ hana:
           $name: Timeout to wait until the primary node is enabled
           $type: text
           $optional: true
+
+      add_exporter:
+        $name: Add SAP HANA database metrics exporter
+        $type: boolean
+        $default: false
+        $help: Mark if you want add the SAP HANA database metrics exporter
+      exporter:
+        $name: SAP HANA database metrics exporter
+        $optional: true
+        $visibleIf: .add_exporter == true
+        $type: group
+        exposition_port:
+          $name: SAP HANA exposter exposition port
+          $type: text
+          $optional: true
+        user:
+          $name: SAP HANA user
+          $type: text
+          $default: SYSTEM
+          $optional: false
+        password:
+          $name: SAP HANA password
+          $type: password
+          $optional: false

--- a/hana/exporter.sls
+++ b/hana/exporter.sls
@@ -1,0 +1,32 @@
+{%- from "hana/map.jinja" import hana with context -%}
+{% set host = grains['host'] %}
+
+{% for node in hana.nodes %}
+{% if node.host == host and node.exporter is defined %}
+
+{% set config_file = '/etc/hanadb_exporter/config_{{ node.sid.lower() }}_{{ '{:0>2}'.format(node.instance) }}.json' %}
+
+hanadb_exporter:
+  pkg.installed
+
+python3-PyHDB:
+  pkg.installed
+
+configure_exporter:
+    file.managed:
+      - source: salt://hana/templates/hanadb_exporter.j2
+      - name: {{ config_file }}
+      - template: jinja
+      - require:
+        - hanadb_exporter
+        - python-PyHDB
+
+start_exporter:
+  cmd.run:
+    - name: hanadb_exporter -c {{ config_file }} -m /etc/hanadb_exporter/metrics.json
+    - unless: ps -ef | grep 'hanadb_exporter -c {{ config_file }} -m /etc/hanadb_exporter/metrics.json'
+    - require:
+        - configure_exporter
+
+{% endif %}
+{% endfor %}

--- a/hana/init.sls
+++ b/hana/init.sls
@@ -8,3 +8,4 @@ include:
   - hana.install
   - hana.enable_primary
   - hana.enable_secondary
+  - hana.exporter

--- a/hana/pre_validation.sls
+++ b/hana/pre_validation.sls
@@ -44,6 +44,11 @@
     {% endif %}
   {% endif %}
   {# Check HANA Systen replication mode finish #}
+  {# Check HANA exporter #}
+  {% if node.add_exporter is defined and node.add_exporter == false%}
+    {% do node.pop('exporter') %}
+  {% endif %}
+  {# Check HANA exporter finish #}
 
   {% endif %}
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -30,6 +30,12 @@ hana:
           user_password: 'Qwerty1234'
           database: 'SYSTEMDB'
           file: 'backup'
+      # Optional: Add hanadb_exporter to the instance
+      exporter:
+        exposition_port: 8001 # Optional, 8001 by default
+        user: 'SYSTEM'
+        password: 'Qwerty1234'
+
 
     - host: 'hana02'
       sid: 'prd'

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun 19 14:23:59 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
+
+- Create package version 0.2.2 adding hanadb_exporter deployment 
+
+-------------------------------------------------------------------
 Tue Jun 11 11:42:31 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
 
 - Create package version 0.2.1 with fixed spec files. Now the package

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.2.1
+Version:        0.2.2
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/templates/hanadb_exporter.j2
+++ b/templates/hanadb_exporter.j2
@@ -1,0 +1,20 @@
+{%- from "hana/map.jinja" import hana with context -%}
+{% set host = grains['host'] %}
+
+{% for node in hana.nodes %}
+{% if node.host == host and node.exporter is defined %}
+
+{% set dbinst = '{:0>2}'.format(node.instance) %}
+
+{
+  "exposition_port": {{ node.exporter.exposition_port|default(8001) }},
+  "hana": {
+    "host": "{{ node.host }}",
+    "port": 3{{ dbinst }}15,
+    "user": "{{ node.exporter.user }}",
+    "password": "{{ node.exporter.password }}"
+  }
+}
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
hanadb_exporter deployment using the formula.
If `exporter` is set in the pillar file it will deploy the exporter with the provided data.
*INFO: The salt execution will work even though the exporter is not correctly started (for example trying to connect to a secondary instance).

Besides that, the logs are not stored yes anywhere (we will add this in the hanadb_exporter project, to make the logging configurable)