### PR TITLE
Fix/sr hook for cost-optimized

### DIFF
--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -32,7 +32,7 @@ setup_srHook_directory:
 install_srTakeover_hook:
     file.managed:
       - source: salt://hana/templates/srTakeover_hook.j2
-      - name: /hana/shared/srHook/sr-Takeover.py
+      - name: /hana/shared/srHook/srTakeover.py
       - user: {{ node.sid.lower() }}adm
       - group: sapsys
       - template: jinja
@@ -60,6 +60,21 @@ install_hana_python_packages:
       - require:
         - reduce_memory_resources_{{ node.host+node.sid }}
         - setup_srHook_directory
+
+configure_ha_dr_provider_srTakeover:
+    file.append:
+      - name:  /hana/shared/{{ node.sid.upper() }}/global/hdb/custom/config/global.ini
+      - text: |
+
+          [ha_dr_provider_srTakeover]
+          provider = srTakeover
+          path = /hana/shared/srHook
+          execution_order = 1
+      - require:
+        - reduce_memory_resources_{{ node.host+node.sid }}
+        - setup_srHook_directory
+        - install_srTakeover_hook
+        - install_hana_python_packages
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -72,8 +72,10 @@ extract_hdbcli_client_files:
 
 remove_hdbcli_tar_package:
     file.absent:
-      - name: /hana/shared/srHook/hdbcli-package.tar.gz
-      
+      - names: 
+        - /hana/shared/srHook/hdbcli-package.tar.gz
+        - /hana/shared/srHook/hdbcli
+
 chmod_hdbcli_client_files:
     file.managed:
       - user: {{ node.sid.lower() }}adm

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -75,7 +75,9 @@ remove_hdbcli_tar_package:
       - names: 
         - /hana/shared/srHook/hdbcli-package.tar.gz
         - /hana/shared/srHook/hdbcli
-
+      - require:
+        - extract_hdbcli_client_files
+        
 chmod_hdbcli_client_files:
     file.managed:
       - user: {{ node.sid.lower() }}adm

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -70,6 +70,10 @@ extract_hdbcli_client_files:
       - require:
         - extract_hana_pydbapi_archive
 
+remove_hdbcli_tar_package:
+    file.absent:
+      - name: /hana/shared/srHook/hdbcli-package.tar.gz
+      
 chmod_hdbcli_client_files:
     file.managed:
       - user: {{ node.sid.lower() }}adm

--- a/templates/srTakeover_hook.j2
+++ b/templates/srTakeover_hook.j2
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 {%- from "hana/map.jinja" import hana with context -%}
 {% set host = grains['host'] %}
 
@@ -29,7 +30,6 @@ dbport="{{ dbport }}"
 {% endif %}
 {% endfor %}
 
-#!/usr/bin/env python2
 """
 Auto-generated HA/DR hook script
 


### PR DESCRIPTION
Contains the fixes for the sr hook to undo changes cost-optimized related parameters on secondary HANA node after takeover

- Make the hdbcli client py files extraction compatible with new HANA revisions, as tarball has different structure in older HANA revisions
- Added the [ha_dr_provider_srTakeover] section to global.ini file 
- Other minor fixes to naming
- Added improvements suggested from other PR https://github.com/SUSE/saphanabootstrap-formula/pull/38

Tested in local environment