### PR TITLE
simplify installation of pattern

### DIFF
--- a/hana/packages.sls
+++ b/hana/packages.sls
@@ -1,17 +1,12 @@
 #required packages to install SAP HANA
 
-{% set pattern_available = 1 %}
 {% if grains['os_family'] == 'Suse' %}
-{% set pattern_available = salt['cmd.retcode']('zypper search patterns-sap-hana') %}
-{% endif %}
-
-{% if pattern_available == 0 %}
-{% set repo = salt['pkg.info_available']('patterns-sap-hana')['patterns-sap-hana']['repository'] %}
-patterns-sap-hana:
-  pkg.installed:
-    - fromrepo: {{ repo }}
+install-patterns-sap-hana:
+  pkg.latest:
+    - name: patterns-sap-hana
+    - refresh: True
     - retry:
-        attempts: 3
+        attempts: 5
         interval: 15
 
 {% else %}

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 28 10:03:32 UTC 2019 - Dario Maiocchi <dmaiocchi@suse.com>
+
+- Simplify pattern installation of formula
+  * remove redundant checks, that shadow erorr in jinja template
+  * improve debug UX 
+
+-------------------------------------------------------------------
 Wed Aug  7 07:46:25 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version bump 0.2.9

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.2.9
+Version:        0.3.0
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Remove the jinja construct and simplify. The goal is to provide better
error because when it fails, it doesn't show any useful error before
with the jinja construct.

I need to test this

fix #51

# TODO (another pr)

Backport this to the other formula here https://github.com/SUSE/habootstrap-formula/blob/9ac90aaeed3d85276960c49db6d4fd9293c67ff3/cluster/packages.sls#L11