### PR TITLE
Updata pkg.info_available call to avoid errors

### DIFF
--- a/hana/packages.sls
+++ b/hana/packages.sls
@@ -6,7 +6,8 @@
 {% endif %}
 
 {% if pattern_available == 0 %}
-{% set repo = salt['pkg.info_available']('patterns-sap-hana')['patterns-sap-hana']['repository'] %}
+# refresh is disabled to avoid errors during the call
+{% set repo = salt['pkg.info_available']('patterns-sap-hana', refresh=False)['patterns-sap-hana']['repository'] %}
 patterns-sap-hana:
   pkg.installed:
     - fromrepo: {{ repo }}

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep  4 06:55:01 UTC 2019 - Xabier Arbulu Insausti <xarbulu@suse.com>
+
+- Update the pkg.info_available call to avoid repositories refresh as
+  it may cause errors
+
+-------------------------------------------------------------------
 Wed Aug  7 07:46:25 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version bump 0.2.9


### PR DESCRIPTION
In order to fix the errors caused during `pkg.info_available`, the `refresh` option is disabled. 
I have tested several times and I have not found the previous issue again.

PD:
This PR comes from the need to fix:
https://github.com/SUSE/saphanabootstrap-formula/pull/52