### PR TITLE
Change Cluster Configuration Template to use `socat` inplace of `netcat` for Azure

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 28 21:28:19 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version bump 0.3.3
+  * Update Cluster template command to use `socat` for Azure
+
+-------------------------------------------------------------------
 Wed Oct 30 16:14:32 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.3.2

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.3.2
+Version:        0.3.3
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -53,8 +53,7 @@ ms msl_SAPHana_{{ sid }}_HDB{{ instance }} rsc_SAPHana_{{ sid }}_HDB{{ instance 
 {% if data.platform == "azure" %}
 
 primitive rsc_nc_{{ sid }}_HDB{{ instance }} anything \
-  params binfile="/usr/bin/nc" cmdline_options="-l -k 62503" \
-  meta resource-stickiness=0 \
+  params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:62503,backlog=10,fork,reuseaddr /dev/null" \
   op monitor timeout="20" interval="10" depth="0"
 
 group g_ip_{{ sid }}_HDB{{ instance }} rsc_ip_{{ sid }}_HDB{{ instance }} rsc_nc_{{ sid }}_HDB{{ instance }}

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -53,7 +53,7 @@ ms msl_SAPHana_{{ sid }}_HDB{{ instance }} rsc_SAPHana_{{ sid }}_HDB{{ instance 
 {% if data.platform == "azure" %}
 
 primitive rsc_nc_{{ sid }}_HDB{{ instance }} anything \
-  params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:62503,backlog=10,fork,reuseaddr /dev/null" \
+  params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:625{{ instance }},backlog=10,fork,reuseaddr /dev/null" \
   op monitor timeout="20" interval="10" depth="0"
 
 group g_ip_{{ sid }}_HDB{{ instance }} rsc_ip_{{ sid }}_HDB{{ instance }} rsc_nc_{{ sid }}_HDB{{ instance }}


### PR DESCRIPTION
Azure changed the Load-Balancer listener to socat as netcat does not allow more than one concurrent connection. For that, we need to install the package socat :
https://github.com/SUSE/habootstrap-formula/pull/33
and correspondingly, our template for HANA (and Netweaver in the future) needs to be adapted to use the updated command, instead of the old nc command.

```
crm configure primitive rsc_nc_HN1_HDB03 anything \
params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:62503,backlog=10,fork,reuseaddr /dev/null" \
op monitor timeout=20s interval=10 depth=0
```
Reference:
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources