### PR TITLE
Add new options to get primary node password

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -55,6 +55,8 @@ hana:
         remote_instance: '00'
         replication_mode: 'sync'
         operation_mode: 'logreplay'
+        # If primary node is not defined the password can we set here (primary node password has preference)
+        #primary_password: 'Qwerty1234'
         # Optional timeout value in seconds to wait until the primary node
         # 100 seconds by default
         primary_timeout: 100

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 10 14:45:55 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Fix the scenario where the primary was not defined during
+  secondary installation. Now the password can be retrieved using
+  other options 
+
+-------------------------------------------------------------------
 Thu Nov 28 21:28:19 UTC 2019 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version bump 0.3.3


### PR DESCRIPTION
The formula has an issue. If the primary node is not defined the secondary cannot be provisioned as it depends in the primary node password. This fixes this issue adding new options to get the primary password.
The options:
The primary password is retrieved in this order
1. If the primary node is defined in the pillar, primary password will be used
2. If secondary.primary_pass is defined this password will be used
3. The secondary machine password will be used