### PR TITLE
Use correct pillar entry to know cloud provider

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 19 12:18:22 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.4.1
+  * Update cloud provider usage 
+
+-------------------------------------------------------------------
 Thu Dec 12 11:52:23 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.4.0

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.4.0
+Version:        0.4.1
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -1,6 +1,7 @@
 {% set data = pillar.cluster.configure.template.parameters %}
 {% set sid = data.sid.upper() %}
 {% set instance = '{:0>2}'.format(data.instance) %}
+{% set cloud_provider = grains['cloud_provider'] %}
 
 #
 # defaults
@@ -17,11 +18,11 @@ op_defaults \
 # production HANA
 #
 
-{% set nic = "nic="~pillar.cluster.interface|default('eth0')|json if data.platform == "gcp" else "nic="~pillar.cluster.interface|json if pillar.cluster.interface is defined else "" %}
+{% set nic = "nic="~pillar.cluster.interface|default('eth0')|json if cloud_provider == "google-cloud-platform" else "nic="~pillar.cluster.interface|json if pillar.cluster.interface is defined else "" %}
 
 primitive rsc_ip_{{ sid }}_HDB{{ instance }} ocf:heartbeat:IPaddr2 \
     params \
-    ip="{{ data.virtual_ip }}" cidr_netmask="{{ 32 if data.platform == "gcp" else data.virtual_ip_mask }}" {{ nic }} \
+    ip="{{ data.virtual_ip }}" cidr_netmask="{{ 32 if cloud_provider == "google-cloud-platform" else data.virtual_ip_mask }}" {{ nic }} \
     op start timeout="20" op stop timeout="20" \
     op monitor interval="10" timeout="20"
 
@@ -52,7 +53,7 @@ primitive rsc_SAPHana_{{ sid }}_HDB{{ instance }} ocf:suse:SAPHana \
 ms msl_SAPHana_{{ sid }}_HDB{{ instance }} rsc_SAPHana_{{ sid }}_HDB{{ instance }} \
     meta clone-max="2" clone-node-max="1" interleave="true"
 
-{% if data.platform == "azure" %}
+{% if cloud_provider == "microsoft-azure" %}
 
 primitive rsc_socat_{{ sid }}_HDB{{ instance }} anything \
   params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:625{{ instance }},backlog=10,fork,reuseaddr /dev/null" \


### PR DESCRIPTION
Use the new `cloud_provider` parameter. As the template is used in habootstrap-formula `grains['cloud_provider']` will always exist.

Depends on: 
https://github.com/SUSE/habootstrap-formula/pull/38

https://github.com/SUSE/habootstrap-formula/pull/38/files#diff-ede8388134830516402a39e126add733R6