### PR TITLE
Pass xml file to install hana if this file is provided

### DIFF
--- a/hana/install.sls
+++ b/hana/install.sls
@@ -16,6 +16,9 @@ hana_install_{{ node.host+node.sid }}:
     - root_password: {{ node.install.root_password }}
     {% if node.install.config_file is defined %}
     - config_file: {{ node.install.config_file }}
+    {% endif %}
+    {% if node.install.hdb_pwd_file is defined %}
+    - hdb_pwd_file: {{ node.install.hdb_pwd_file }}
     {% else %}
     - system_user_password: {{ node.install.system_user_password }}
     - sapadm_password: {{ node.install.sapadm_password }}

--- a/pillar.example
+++ b/pillar.example
@@ -13,7 +13,7 @@ hana:
         root_user: 'root'
         root_password: 's'
         # Fetch HANA passwords from XML file 
-        hdb_pwd_file: '/root/passwords.xml'
+        hdb_pwd_file: 'salt://passwords.xml'
         # Or specify HANA system & sapadm users' passwords like below
         system_user_password: 'Qwerty1234'
         sapadm_password: 'Qwerty1234'

--- a/pillar.example
+++ b/pillar.example
@@ -12,6 +12,9 @@ hana:
         software_path: '/root/sap_inst/51052481'
         root_user: 'root'
         root_password: 's'
+        # Fetch HANA passwords from XML file 
+        hdb_pwd_file: '/root/passwords.xml'
+        # Or specify HANA system & sapadm users' passwords like below
         system_user_password: 'Qwerty1234'
         sapadm_password: 'Qwerty1234'
       primary:

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan  2 23:25:35 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.4.2
+  * Add the option to specify password XML file for installing hana
+
+-------------------------------------------------------------------
 Thu Dec 19 12:18:22 UTC 2019 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.4.1

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.4.1
+Version:        0.4.2
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Add the option to pass xml file containing passwords for installing hana.
system_user_password/sapadm_password in pillar will used if XML file is not provided
Related PR:
https://github.com/SUSE/shaptools/pull/48
https://github.com/SUSE/salt-shaptools/pull/46