### PR TITLE
Feature/install pydbapi

### DIFF
--- a/hana/exporter.sls
+++ b/hana/exporter.sls
@@ -8,13 +8,10 @@
 {% set config_file = '/etc/hanadb_exporter/{}.json'.format(daemon_instance) %}
 
 {% if loop.first %}
-prometheus-hanadb_exporter:
-  pkg.installed:
-  - retry:
-      attempts: 3
-      interval: 15
+include:
+  - hana.install_pydbapi
 
-python3-PyHDB:
+prometheus-hanadb_exporter:
   pkg.installed:
   - retry:
       attempts: 3
@@ -52,5 +49,6 @@ start_exporter_{{ daemon_instance }}:
     - reload: True
     - require:
         - configure_exporter_{{ daemon_instance }}
+        - hana_install_pydbapi_client
 
 {% endfor %}

--- a/hana/install_pydbapi.sls
+++ b/hana/install_pydbapi.sls
@@ -19,7 +19,7 @@ hana_install_python_pip:
 hana_extract_pydbapi_client:
   hana.pydbapi_extracted:
     - name: PYDBAPI.TGZ
-    - software_folders: [{{ node.install.software_path }}]
+    - software_folders: [{{ node.exporter.hana_client_path|default(node.install.software_path) }}]
     - output_dir: {{ pydbapi_output_dir }}
     - hana_version: '20'
     - force: true

--- a/hana/install_pydbapi.sls
+++ b/hana/install_pydbapi.sls
@@ -1,0 +1,46 @@
+{%- from "hana/map.jinja" import hana with context -%}
+{% set host = grains['host'] %}
+
+{% for node in hana.nodes if node.host == host %}
+{% if loop.first %}
+{% set pydbapi_output_dir = '/tmp/pydbapi' %}
+hana_install_python_pip:
+  pkg.installed:
+    {% if grains['pythonversion'][0] == 2 %}
+    - name: python-pip
+    {% else %}
+    - name: python3-pip
+    {% endif %}
+    - retry:
+        attempts: 3
+        interval: 15
+    - resolve_capabilities: true
+
+hana_extract_pydbapi_client:
+  hana.pydbapi_extracted:
+    - name: PYDBAPI.TGZ
+    - software_folders: [{{ node.install.software_path }}]
+    - output_dir: {{ pydbapi_output_dir }}
+    - hana_version: '20'
+    - force: true
+
+# pip.installed fails as it cannot manage propler file names with regular expressions
+# TODO: Improve this to use pip.installed somehow
+hana_install_pydbapi_client:
+  cmd.run:
+    {% if grains['pythonversion'][0] == 2 %}
+    - name: /usr/bin/python -m pip install {{ pydbapi_output_dir }}/hdbcli-*.tar.gz
+    {% else %}
+    - name: /usr/bin/python3 -m pip install {{ pydbapi_output_dir }}/hdbcli-*.tar.gz
+    {% endif %}
+    - require:
+      - hana_install_python_pip
+      - hana_extract_pydbapi_client
+
+hana_remove_pydbapi_client:
+  file.absent:
+    - name: {{ pydbapi_output_dir }}
+    - onchanges:
+      - hana_extract_pydbapi_client
+{% endif %}
+{% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -5,7 +5,7 @@ hana:
   # install_packages: true
 
   # saptune solution to apply to all nodes ( by default nothing is applied)
-  # you can also use this to a single node if need to differ. see hana2 
+  # you can also use this to a single node if need to differ. see hana2
   # Warning: only a unique solution can exist into a node.
   saptune_solution: 'HANA'
 
@@ -18,7 +18,7 @@ hana:
         software_path: '/root/sap_inst/51052481'
         root_user: 'root'
         root_password: 's'
-        # Fetch HANA passwords from XML file 
+        # Fetch HANA passwords from XML file
         hdb_pwd_file: 'salt://passwords.xml'
         # Or specify HANA system & sapadm users' passwords like below
         system_user_password: 'Qwerty1234'
@@ -47,6 +47,8 @@ hana:
         password: 'Qwerty1234'
         #port: 30015 # HANA database port. If multi_tenant is set this value is 3XX13 by default where XX is the instance number
         timeout: 600 # Timeout in seconds to start the connection with HANA database
+        # Set the path of the HANA Client folder, if it is not set, the node software_path will be used
+        #hana_client_path: /hana_client_path
 
     - host: 'hana02'
       sid: 'prd'

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 20 13:19:03 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.5.2
+  * Install pydbapi package to be used by hanadb_exporter
+
+-------------------------------------------------------------------
 Tue Mar  3 09:51:59 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.1

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.5.1
+Version:        0.5.2
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Right now, the hanadb_exporter is using PyHDB to connect to the HANA database. PyHDB is not an officially supported package.
Python dbapi is officially provided by SAP, so this change installs this package.

The change adds an optional new variable: `hana_client_path`
This parameter is used in the `exporter` field, if the user wants to provide a specific HANA version. Remember that the HANA client is not always available in the `software_path` parameter, as this can only store the database.

PD: In this occasion we don't need to reload the hdb_connector package as in sapnwbootstrap-formula, as the python package is used by the exporter, so not during the installation process