### PR TITLE
Feature/sapcar support 

### DIFF
--- a/hana/defaults.yaml
+++ b/hana/defaults.yaml
@@ -1,3 +1,4 @@
 hana:
   install_packages: true
+  hdbserver_extract_dir: /sapmedia/HANA
   nodes: []

--- a/hana/extract_hdbserver.sls
+++ b/hana/extract_hdbserver.sls
@@ -1,6 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
 
-{% if hana.hdbserver_sar_file and hana.sapcar_exe_file is defined %}
+{% if hana.hdbserver_sar_file is defined and hana.sapcar_exe_file is defined %}
 
 extract_hdbserver_sar:
     sapcar.extracted:

--- a/hana/extract_hdbserver.sls
+++ b/hana/extract_hdbserver.sls
@@ -1,0 +1,22 @@
+{%- from "hana/map.jinja" import hana with context -%}
+{% set host = grains['host'] %}
+
+{% if hana.hdbserver_sar_file and hana.sapcar_exe_file is defined %}
+
+extract_hdbserver_sar_{{ host }}:
+    sapcar.extracted:
+    - name: {{ hana.hdbserver_sar_file }}
+    - sapcar_exe: {{ hana.sapcar_exe_file }}
+    - output_dir: {{ hana.hdbserver_extract_dir }}
+    - options: "-manifest SIGNATURE.SMF"
+
+copy_signature_file_to_installer_dir_{{ host }}:
+    file.copy:
+    - source: {{ hana.hdbserver_extract_dir }}/SIGNATURE.SMF
+    - name: {{ hana.hdbserver_extract_dir }}/SAP_HANA_DATABASE/SIGNATURE.SMF
+    - preserve: True
+    - force: True
+    - require:
+        - extract_hdbserver_sar_{{ host }}
+
+{% endif %}

--- a/hana/extract_hdbserver.sls
+++ b/hana/extract_hdbserver.sls
@@ -1,22 +1,21 @@
 {%- from "hana/map.jinja" import hana with context -%}
-{% set host = grains['host'] %}
 
 {% if hana.hdbserver_sar_file and hana.sapcar_exe_file is defined %}
 
-extract_hdbserver_sar_{{ host }}:
+extract_hdbserver_sar:
     sapcar.extracted:
     - name: {{ hana.hdbserver_sar_file }}
     - sapcar_exe: {{ hana.sapcar_exe_file }}
     - output_dir: {{ hana.hdbserver_extract_dir }}
     - options: "-manifest SIGNATURE.SMF"
 
-copy_signature_file_to_installer_dir_{{ host }}:
+copy_signature_file_to_installer_dir:
     file.copy:
     - source: {{ hana.hdbserver_extract_dir }}/SIGNATURE.SMF
     - name: {{ hana.hdbserver_extract_dir }}/SAP_HANA_DATABASE/SIGNATURE.SMF
     - preserve: True
     - force: True
     - require:
-        - extract_hdbserver_sar_{{ host }}
+        - extract_hdbserver_sar
 
 {% endif %}

--- a/hana/init.sls
+++ b/hana/init.sls
@@ -6,6 +6,7 @@ include:
 {% endif %}
   - hana.pre_validation
   - hana.saptune
+  - hana.extract_hdbserver
   - hana.install
   - hana.enable_primary
   - hana.enable_secondary

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -7,9 +7,9 @@ include:
 {% for node in hana.nodes if node.host == host and node.install is defined %}
 
 {% if hana.software_path is defined or node.install.software_path is defined  %}
-{% set software_path =  node.install.software_path|default(hana.software_path) %}
+{% set software_path = node.install.software_path|default(hana.software_path) %}
 {% else %}
-{% set software_path =  hana.hdbserver_extract_dir %}
+{% set software_path = hana.hdbserver_extract_dir %}
 {% endif %}
 
 hana_install_{{ node.host+node.sid }}:

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -6,18 +6,12 @@ include:
 
 {% for node in hana.nodes if node.host == host and node.install is defined %}
 
-{% if hana.software_path is defined or node.install.software_path is defined  %}
-{% set software_path = node.install.software_path|default(hana.software_path) %}
-{% else %}
-{% set software_path = hana.hdbserver_extract_dir %}
-{% endif %}
-
 hana_install_{{ node.host+node.sid }}:
   hana.installed:
     - name: {{ node.sid }}
     - inst: {{ node.instance }}
     - password: {{ node.password }}
-    - software_path: {{ software_path }}
+    - software_path: {{ node.install.software_path|default(hana.software_path)|default(hana.hdbserver_extract_dir) }}
     - root_user: {{ node.install.root_user }}
     - root_password: {{ node.install.root_password }}
     {% if node.install.config_file is defined %}

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -6,12 +6,18 @@ include:
 
 {% for node in hana.nodes if node.host == host and node.install is defined %}
 
+{% if hana.software_path is defined or node.install.software_path is defined  %}
+{% set software_path =  node.install.software_path|default(hana.software_path) %}
+{% else %}
+{% set software_path =  hana.hdbserver_extract_dir %}
+{% endif %}
+
 hana_install_{{ node.host+node.sid }}:
   hana.installed:
     - name: {{ node.sid }}
     - inst: {{ node.instance }}
     - password: {{ node.password }}
-    - software_path: {{ node.install.software_path }}
+    - software_path: {{ software_path }}
     - root_user: {{ node.install.root_user }}
     - root_password: {{ node.install.root_password }}
     {% if node.install.config_file is defined %}

--- a/hana/install_pydbapi.sls
+++ b/hana/install_pydbapi.sls
@@ -16,10 +16,20 @@ hana_install_python_pip:
         interval: 15
     - resolve_capabilities: true
 
+# The software_folders is retrieved in this order: 
+# 1. node.exporter.hana_client_path
+# 2. node.install.software_path
+# 3. hana.software_path
+{% if node.exporter.hana_client_path is defined or node.install.software_path is defined  %}
+{% set software_folders = node.exporter.hana_client_path|default(node.install.software_path) %}
+{% else %}
+{% set software_folders = hana.software_path %}
+{% endif %}
+
 hana_extract_pydbapi_client:
   hana.pydbapi_extracted:
     - name: PYDBAPI.TGZ
-    - software_folders: [{{ node.exporter.hana_client_path|default(node.install.software_path) }}]
+    - software_folders: [{{ software_folders }}]
     - output_dir: {{ pydbapi_output_dir }}
     - hana_version: '20'
     - force: true

--- a/hana/install_pydbapi.sls
+++ b/hana/install_pydbapi.sls
@@ -1,7 +1,7 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {% set host = grains['host'] %}
 
-{% for node in hana.nodes if node.host == host %}
+{% for node in hana.nodes if node.host == host and (node.exporter.hana_client_path is defined or node.install.software_path is defined or hana.software_path is defined) %}
 {% if loop.first %}
 {% set pydbapi_output_dir = '/tmp/pydbapi' %}
 hana_install_python_pip:

--- a/hana/install_pydbapi.sls
+++ b/hana/install_pydbapi.sls
@@ -16,20 +16,10 @@ hana_install_python_pip:
         interval: 15
     - resolve_capabilities: true
 
-# The software_folders is retrieved in this order: 
-# 1. node.exporter.hana_client_path
-# 2. node.install.software_path
-# 3. hana.software_path
-{% if node.exporter.hana_client_path is defined or node.install.software_path is defined  %}
-{% set software_folders = node.exporter.hana_client_path|default(node.install.software_path) %}
-{% else %}
-{% set software_folders = hana.software_path %}
-{% endif %}
-
 hana_extract_pydbapi_client:
   hana.pydbapi_extracted:
     - name: PYDBAPI.TGZ
-    - software_folders: [{{ software_folders }}]
+    - software_folders: [{{ node.exporter.hana_client_path|default(node.install.software_path)|default(hana.software_path) }}]
     - output_dir: {{ pydbapi_output_dir }}
     - hana_version: '20'
     - force: true

--- a/pillar.example
+++ b/pillar.example
@@ -11,11 +11,12 @@ hana:
   
   # Specify the path to the sapcar executable & HANA database server installation sar archive
   # The sar archive will be extracted to path specified at hdbserver_extract_dir (optional, by default /sapmedia/HANA)
-  sapcar_exe_file: '/root/sap_inst/sapcar.exe'
-  hdbserver_sar_file: '/root/sap_inst/IMDB_SERVER_LINUX.SAR'
-  hdbserver_extract_dir:'/root/sap_inst/IMDB_SERVER_LINUX" 
+  # Make sure to use the latest/compatible version of sapcar executable, otherwise file may be extracted incorrectly
+  sapcar_exe_file: '/sapmedia/sapcar.exe'
+  hdbserver_sar_file: '/sapmedia/IMDB_SERVER_LINUX.SAR'
+  hdbserver_extract_dir: '/sapmedia/HANA'
   # Or specify the path to already extracted HANA platform installation media
-  software_path: '/root/sap_inst/51052481'
+  software_path: '/sapmedia/HANA/51052481'
 
   nodes:
     - host: 'hana01'
@@ -26,7 +27,7 @@ hana:
         # Specify the path to local installation media here, otherwise global variable software_path will be used for installation media 
         # If both of these paths are not set, hdbserver_extract_dir path will be used for installation media, 
         # given that sapcar_exe_file & hdbserver_sar_file package is also provided
-        software_path: '/root/sap_inst/51052481'
+        software_path: '/sapmedia/HANA/51052481'
         root_user: 'root'
         root_password: 's'
         # Fetch HANA passwords from XML file
@@ -67,7 +68,7 @@ hana:
       password: 'Qwerty1234'
       saptune_solution: 'MAXDB'
       install:
-        software_path: '/root/sap_inst/51052481'
+        software_path: '/sapmedia/HANA/51052481'
         root_user: 'root'
         root_password: 's'
         system_user_password: 'Qwerty1234'
@@ -97,7 +98,7 @@ hana:
       instance: 01
       password: 'Qwerty1234'
       install:
-        software_path: '/root/sap_inst/51052481'
+        software_path: '/sapmedia/HANA/51052481'
         root_user: 'root'
         root_password: 's'
         system_user_password: 'Qwerty1234'

--- a/pillar.example
+++ b/pillar.example
@@ -8,6 +8,14 @@ hana:
   # you can also use this to a single node if need to differ. see hana2
   # Warning: only a unique solution can exist into a node.
   saptune_solution: 'HANA'
+  
+  # Specify the path to the sapcar executable & HANA database server installation sar archive
+  # The sar archive will be extracted to path specified at hdbserver_extract_dir (optional, by default /sapmedia/HANA)
+  sapcar_exe_file: '/root/sap_inst/sapcar.exe'
+  hdbserver_sar_file: '/root/sap_inst/IMDB_SERVER_LINUX.SAR'
+  hdbserver_extract_dir:'/root/sap_inst/IMDB_SERVER_LINUX" 
+  # Or specify the path to already extracted HANA platform installation media
+  software_path: '/root/sap_inst/51052481'
 
   nodes:
     - host: 'hana01'
@@ -15,6 +23,9 @@ hana:
       instance: 00
       password: 'Qwerty1234'
       install:
+        # Specify the path to local installation media here, otherwise global variable software_path will be used for installation media 
+        # If both of these paths are not set, hdbserver_extract_dir path will be used for installation media, 
+        # given that sapcar_exe_file & hdbserver_sar_file package is also provided
         software_path: '/root/sap_inst/51052481'
         root_user: 'root'
         root_password: 's'

--- a/pillar.example
+++ b/pillar.example
@@ -9,14 +9,15 @@ hana:
   # Warning: only a unique solution can exist into a node.
   saptune_solution: 'HANA'
   
-  # Specify the path to the sapcar executable & HANA database server installation sar archive
+  # Specify the path to already extracted HANA platform installation media
+  # This will have preference over hdbserver sar archive installation media
+  software_path: '/sapmedia/HANA/51052481'
+  # Or specify the path to the sapcar executable & HANA database server installation sar archive
   # The sar archive will be extracted to path specified at hdbserver_extract_dir (optional, by default /sapmedia/HANA)
   # Make sure to use the latest/compatible version of sapcar executable, otherwise file may be extracted incorrectly
   sapcar_exe_file: '/sapmedia/sapcar.exe'
   hdbserver_sar_file: '/sapmedia/IMDB_SERVER_LINUX.SAR'
   hdbserver_extract_dir: '/sapmedia/HANA'
-  # Or specify the path to already extracted HANA platform installation media
-  software_path: '/sapmedia/HANA/51052481'
 
   nodes:
     - host: 'hana01'

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 25 21:34:17 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.5.3
+ * Add support to run sapcar and extract HANA sar package 
+
+-------------------------------------------------------------------
 Fri Mar 20 13:19:03 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.2

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.5.2
+Version:        0.5.3
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Adding the sapcar extraction functionality to extract HANA database sar file.
With this PR, I allow did following changes to how HANA installation works.

- Set a Default extraction directory for hana: `/sapmedia/HANA`

- Added a global `software_path` variable, The precedence for hana install media now looks like this: `local node entry for software_path` > `global software_path` > `hdbserver_extract_dir`
I have added in pillar notes that `hdbserver_extract_dir` will be used if both `software_path` are not provided

- Copy the `SIGNATURE.SMF` to  directory containing `hdblcm` executable (ie `SAP_HANA_DATABASE`)