### PR TITLE
Feature/gcp instance

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 27 11:16:16 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.5.3
+  * Update the fence_gce usage to use gcp_instance_id 
+
+-------------------------------------------------------------------
 Fri Mar 20 13:19:03 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.2

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.5.2
+Version:        0.5.3
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -52,7 +52,7 @@ colocation col_saphana_ip_{{ sid }}_HDB{{ instance }} 2000: rsc_aws_vip_{{ sid }
 
 # This stonith resource will be duplicated for each node in the cluster
 primitive rsc_gcp_stonith_{{ sid }}_HDB{{ instance }}_{{ grains['host'] }} stonith:fence_gce \
-    params plug={{ grains['gcp_instance_id'] }} \
+    params plug={{ grains['gcp_instance_id'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['gcp_instance_id'] }}" \
     meta target-role=Started
 
 primitive rsc_gcp_vip_{{ sid }}_HDB{{ instance }} ocf:heartbeat:gcp-vpc-move-route \

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -52,7 +52,7 @@ colocation col_saphana_ip_{{ sid }}_HDB{{ instance }} 2000: rsc_aws_vip_{{ sid }
 
 # This stonith resource will be duplicated for each node in the cluster
 primitive rsc_gcp_stonith_{{ sid }}_HDB{{ instance }}_{{ grains['host'] }} stonith:fence_gce \
-    params action=reboot plug={{ grains['host'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['host'] }}" \
+    params plug={{ grains['gcp_instance_id'] }} \
     meta target-role=Started
 
 primitive rsc_gcp_vip_{{ sid }}_HDB{{ instance }} ocf:heartbeat:gcp-vpc-move-route \


### PR DESCRIPTION
Improve `fence_gce` usage using the `gcp_instance_id` created in: https://github.com/SUSE/habootstrap-formula/pull/46

Right now, we were assuming that the hostname is the same as the instance name. This is true in most of the cases, but the hostname can be customized as well, so this change makes the usage always correct.

Besides that, I have remove useless `action` and `pcmk_host_map`. They are not needed.