### PR TITLE
Feature/use azure lb

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr 14 13:28:03 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.5.6
+  * Update anyting socat resource by azure-lb as recommended in
+  the updated best practices guide
+
+-------------------------------------------------------------------
 Tue Mar 31 07:25:29 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.5
@@ -8,13 +15,13 @@ Tue Mar 31 07:25:29 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 Fri Mar 27 11:16:16 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.4
-  * Update the fence_gce usage to use gcp_instance_id 
-  
+  * Update the fence_gce usage to use gcp_instance_id
+
 -------------------------------------------------------------------
 Wed Mar 25 21:34:17 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.5.3
- * Add support to run sapcar and extract HANA sar package 
+ * Add support to run sapcar and extract HANA sar package
 
 -------------------------------------------------------------------
 Fri Mar 20 13:19:03 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.5.5
+Version:        0.5.6
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -65,8 +65,8 @@ colocation col_saphana_ip_{{ sid }}_HDB{{ instance }} 2000: rsc_gcp_vip_{{ sid }
 
 {%- elif cloud_provider == "microsoft-azure" %}
 
-primitive rsc_socat_{{ sid }}_HDB{{ instance }} anything \
-    params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:625{{ instance }},backlog=10,fork,reuseaddr /dev/null" \
+primitive rsc_socat_{{ sid }}_HDB{{ instance }} azure-lb \
+    params port=625{{ instance }} \
     op monitor timeout="20" interval="10" depth="0"
 
 group g_ip_{{ sid }}_HDB{{ instance }} rsc_ip_{{ sid }}_HDB{{ instance }} rsc_socat_{{ sid }}_HDB{{ instance }}


### PR DESCRIPTION
Update load-balancer resource agent.
I have kept the `rsc_socat` nomenclature as in SUSE distros it uses socat instead `nc`, so it makes sense (replacing by `nc` as the guide suggests is confusing)
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability