### PR TITLE
Hotfix/use gcp instance name

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 17 08:14:08 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Version 0.5.7
+  * Use gcp instance name instead of id in fence_gce agent
+  (bsc#1161898, bsc#1160933)
+
+-------------------------------------------------------------------
 Tue Apr 14 13:28:03 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.6

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.5.6
+Version:        0.5.7
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -52,7 +52,7 @@ colocation col_saphana_ip_{{ sid }}_HDB{{ instance }} 2000: rsc_aws_vip_{{ sid }
 
 # This stonith resource will be duplicated for each node in the cluster
 primitive rsc_gcp_stonith_{{ sid }}_HDB{{ instance }}_{{ grains['host'] }} stonith:fence_gce \
-    params plug={{ grains['gcp_instance_id'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['gcp_instance_id'] }}" \
+    params plug={{ grains['gcp_instance_name'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['gcp_instance_name'] }}" \
     meta target-role=Started
 
 primitive rsc_gcp_vip_{{ sid }}_HDB{{ instance }} ocf:heartbeat:gcp-vpc-move-route \


### PR DESCRIPTION
Fix fence_gce usage. Instance name must be used to make `fence_gce` work without providing the gcp `zone`

Depends on: https://github.com/SUSE/habootstrap-formula/pull/47