### PR TITLE
Feature/adjust cost optimized

### DIFF
--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -50,7 +50,8 @@ failure:
     - failhard: True
 {% endif %}
 
-{% set py_packages_folder = '{}/DATA_UNITS/HDB_CLIENT_LINUX_{}/client/PYDBAPI.TGZ'.format(grains['hana_inst_folder'], platform) %}
+{% set software_folder = node.install.software_path|default(hana.software_path) %}
+{% set py_packages_folder = '{}/DATA_UNITS/HDB_CLIENT_LINUX_{}/client/PYDBAPI.TGZ'.format(software_folder, platform) %}
 
 extract_hana_pydbapi_archive:
     archive.extracted:

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr 21 02:21:28 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.5.8
+  * Adjust software_path usage for cost optimized scenario 
+
+-------------------------------------------------------------------
 Fri Apr 17 08:14:08 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version 0.5.7

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.5.7
+Version:        0.5.8
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0


### PR DESCRIPTION
Adjusting the `py_packages_folder` used for cost optimized required packages `pydbapi.tgz` and `hdbcli` archive.
Previously grains entry `hana_inst_folder` was used, which may not be ideal to use in formula. I have updated it to fetch the client packages from `software_path` variable.

Another solution is to update our salt function `pydbapi_extracted` & consider passing the extra options there for extracting pydbapi archive. However, as the structure for pydbapi varies for HANA versions, as well the hdbcli package versions inside have different structure across HANA revisions, we may still need to use the current salt `archive.extracted`

Tested these changes with cost optimized deployment and works as expected. I also tested the existing formula and it was working fine as well