### PR TITLE
Update colocation weight for col_saphana_ip for Azure provider

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  2 00:21:55 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.5.10
+  * Change colocation weight for col_saphana_ip for Azure provider 
+
+-------------------------------------------------------------------
 Fri May 15 01:55:38 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.5.9

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -19,7 +19,7 @@
 # See also http://en.opensuse.org/openSUSE:Specfile_guidelines
 
 Name:           saphanabootstrap-formula
-Version:        0.5.9
+Version:        0.5.10
 Release:        0
 Summary:        SAP HANA platform deployment formula
 License:        Apache-2.0

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -72,7 +72,7 @@ primitive rsc_socat_{{ sid }}_HDB{{ instance }} azure-lb \
 
 group g_ip_{{ sid }}_HDB{{ instance }} rsc_ip_{{ sid }}_HDB{{ instance }} rsc_socat_{{ sid }}_HDB{{ instance }}
 
-colocation col_saphana_ip_{{ sid }}_HDB{{ instance }} 2000: g_ip_{{ sid }}_HDB{{ instance }}:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Master
+colocation col_saphana_ip_{{ sid }}_HDB{{ instance }} 4000: g_ip_{{ sid }}_HDB{{ instance }}:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Master
 
 {%- else %}
 colocation col_saphana_ip_{{ sid }}_HDB{{ instance }} 2000: rsc_ip_{{ sid }}_HDB{{ instance }}:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Master


### PR DESCRIPTION
Updating the colocation weight in cluster template for Azure
as `g_ip_{{ sid }}_HDB{{ instance }}` was not moving together with current SAP master

 Fixes:https://github.com/SUSE/saphanabootstrap-formula/issues/85 and tested with azure deployment.

Reference:
-https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability

-https://github.com/MicrosoftDocs/azure-docs/commit/f6bead3aae6e5b067ee113597a0cc57cdbaf46f2