### PR TITLE
Add HANA active/active resources to the template

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -35,7 +35,7 @@ hana:
       password: 'Qwerty1234'
       install:
         # Specify the path to local installation media here, otherwise global variable software_path will be used for installation media.
-        # If both of these paths are not set, hana_extract_dir path will be used for installation media, 
+        # If both of these paths are not set, hana_extract_dir path will be used for installation media,
         # given that hana_archive_file package is also provided
         software_path: '/sapmedia/HANA/51052481'
         root_user: 'root'
@@ -90,6 +90,8 @@ hana:
         remote_instance: '00'
         replication_mode: 'sync'
         operation_mode: 'logreplay'
+        # For Active/Active HANA setup
+        #operation_mode: 'logreplay_readaccess'
         # If primary node is not defined the password can we set here (primary node password has preference)
         #primary_password: 'Qwerty1234'
         # Optional timeout value in seconds to wait until the primary node

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 15 10:30:22 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
+
+- Add hana active/active resources to the cluster template
+- Change `route_table` by `route_name` to make the variable usage
+  more meaningful
+
+-------------------------------------------------------------------
 Wed Jun 10 01:49:02 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Add support to extract zip,rar,exe,sar hana media

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -57,7 +57,7 @@ primitive rsc_gcp_stonith_{{ sid }}_HDB{{ instance }}_{{ grains['host'] }} stoni
     meta target-role=Started
 
 primitive rsc_gcp_vip_{{ sid }}_HDB{{ instance }} ocf:heartbeat:gcp-vpc-move-route \
-    params ip={{ data.virtual_ip }} vpc_network={{ data.vpc_network_name }} route_name={{ data.route_table }} \
+    params ip={{ data.virtual_ip }} vpc_network={{ data.vpc_network_name }} route_name={{ data.route_name }} \
     op start interval=0 timeout=180 \
     op stop interval=0 timeout=180 \
     op monitor interval=60 timeout=60
@@ -135,6 +135,54 @@ colocation col_{{ qas_sid }}_never_with_{{ sid }}-ip -inf: rsc_SAP_{{ qas_sid }}
 order ord_{{ qas_sid }}_stop_before_{{ sid }}-promote Mandatory: rsc_SAP_{{ qas_sid }}_HDB{{ qas_instance }}:stop \
    msl_SAPHana_{{ sid }}_HDB{{ instance }}:promote
 
+{%- endif %}
+
+# Active/Active HANA resources
+
+{%- if data.virtual_ip_secondary is defined %}
+{%- if cloud_provider not in ["amazon-web-services", "google-cloud-platform"] %}
+
+primitive rsc_ip_{{ sid }}_HDB{{ instance }}_readenabled ocf:heartbeat:IPaddr2 \
+    op monitor interval="10s" timeout="20s" \
+    params ip={{ data.virtual_ip_secondary }}
+
+{%- elif cloud_provider == "amazon-web-services" %}
+
+primitive rsc_ip_{{ sid }}_HDB{{ instance }}_readenabled ocf:suse:aws-vpc-move-ip \
+    params ip={{ data.virtual_ip_secondary }} routing_table={{ data.route_table }} \
+    interface={{ pillar.cluster.interface|default('eth0')|json }} profile={{ data.cluster_profile }} \
+    op start interval=0 timeout=180 \
+    op stop interval=0 timeout=180 \
+    op monitor interval=60 timeout=60
+
+{%- elif cloud_provider == "google-cloud-platform" %}
+
+primitive rsc_ip_{{ sid }}_HDB{{ instance }}_readenabled ocf:heartbeat:gcp-vpc-move-route \
+    params ip={{ data.virtual_ip_secondary }} vpc_network={{ data.vpc_network_name }} route_name={{ data.route_name_secondary }} \
+    op start interval=0 timeout=180 \
+    op stop interval=0 timeout=180 \
+    op monitor interval=60 timeout=60
+
+{%- endif %}
+
+{%- if cloud_provider == "microsoft-azure" %}
+
+primitive rsc_socat_{{ sid }}_HDB{{ instance }}_readenabled azure-lb \
+    params port=626{{ instance }} \
+    op monitor timeout="20" interval="10" depth="0"
+
+group g_ip_{{ sid }}_HDB{{ instance }}_readenabled \
+    rsc_ip_{{ sid }}_HDB{{ instance }}_readenabled rsc_socat_{{ sid }}_HDB{{ instance }}_readenabled
+
+colocation col_saphana_ip_{{ sid }}_HDB{{ instance }}_readenabled 4000: \
+    g_ip_{{ sid }}_HDB{{ instance }}_readenabled:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Slave
+
+{%- else %}
+
+colocation col_saphana_ip_{{ sid }}_HDB{{ instance }}_readenabled 2000: \
+    rsc_ip_{{ sid }}_HDB{{ instance }}_readenabled:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Slave
+
+{%- endif %}
 {%- endif %}
 
 # hanadb_exporter resource


### PR DESCRIPTION
Add the HANA active/active setup cluster resources to the template. To use the active/active setup:
- The `operation_mode` must be `logreplay_readaccess` in the hana.sls file
- The entry `virtual_ip_secondary` must be added to the `cluster.sls` file (and `route_name_secondary` for GCP case) (this belongs to `habootstrap-formula` anyway`) Something like:
```
template:
      source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
      parameters:
        ...
        virtual_ip_secondary: 192.168.1.15
        route_name_secondary: gcp_route_name # only for GCP
        ...
```

Docs about Active/Active setup:
https://documentation.suse.com/sbp/all/html/SLES4SAP-hana-sr-guide-PerfOpt-12/index.html#_activeactive_read_enabled_scenario
https://help.sap.com/viewer/4e9b18c116aa42fc84c7dbfd02111aba/2.0.04/en-US/8231617177f743d1ba46fdfc5a82dcd1.html