### PR TITLE
Fix pillar.example file location in package

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Find the latest development repositories at  SUSE's Open Build Service[network:h
 
 ```
 git clone https://github.com/SUSE/saphanabootstrap-formula
-cp -R cluster /srv/salt
+cp -R hana /srv/salt
 ```
 
 **Important!** The formulas depends on [salt-shaptools](https://github.com/SUSE/salt-shaptools) package. Make sure it is installed properly if you follow the manual installation (the package can be installed as a RPM package too).

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -54,8 +54,7 @@ mkdir -p %{buildroot}%{fdir}/states/%{fname}
 mkdir -p %{buildroot}%{fdir}/metadata/%{fname}
 cp -R %{fname} %{buildroot}%{fdir}/states
 cp -R %{ftemplates} %{buildroot}%{fdir}/states/%{fname}
-cp pillar.example %{buildroot}%{fdir}/states/%{fname}
-cp -R form.yml %{buildroot}%{fdir}/metadata/%{fname}
+cp -R form.yml pillar.example %{buildroot}%{fdir}/metadata/%{fname}
 if [ -f metadata.yml ]
 then
   cp -R metadata.yml %{buildroot}%{fdir}/metadata/%{fname}


### PR DESCRIPTION
Changing the location of `pillar.example` file in package,
and fix typo in readme