### PR TITLE
WIP: Make hana installation working without posix attributes

### DIFF
--- a/hana/install.sls
+++ b/hana/install.sls
@@ -48,4 +48,8 @@ hana_install_{{ node.host+node.sid }}:
       - {{ key }}: {{ value }}
       {% endfor %}
     {% endif %}
+   {% if grains.get('ad_server', True) %}
+   - require:
+      - cmd: add_sidadm_grains
+   {% endif %}
 {% endfor %}

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -10,8 +10,8 @@ include:
 add_sidadm_grains:
   cmd.run:
     - name: |
-        sed -i '/ad_sid_uid/d' /etc/salt/grains
-        sed -i '/ad_sid_gid/d' /etc/salt/grains
+        sed -i '/sid_uid/d' /etc/salt/grains
+        sed -i '/sid_gid/d' /etc/salt/grains
         echo "sid_uid: `id {{node.sid}}adm -u`" >> /etc/salt/grains
         echo "sid_gid: `id {{node.sid}}adm -g`" >> /etc/salt/grains
 

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -6,19 +6,6 @@ include:
 
 {% for node in hana.nodes if node.host == host and node.install is defined %}
 
-# TODO:
-# 0) check with 
-
-# realmd list | grep active  -> this give dinamically if node is connected to AD
-
-
-#populate variable with ID and GID set dinamically by sssd
-# 1) get_id
-
-
-# 2) get_uid
-
-
 hana_install_{{ node.host+node.sid }}:
   hana.installed:
     - name: {{ node.sid }}
@@ -38,9 +25,9 @@ hana_install_{{ node.host+node.sid }}:
     {% endif %}
     - extra_parameters:
       - hostname: {{ node.host }}
-    {% if ad_connected is True %}
-      - userid:  {{node_ad_uid}}
-      - groupid: {{node_ad_groupid}}
+    {% if grains.get('sidadm_ad_groupid', False) and grains.get('sidadm_ad_userid', False) %}
+      - userid:  {{ sidadm_ad_userid }}
+      - groupid: {{ sidadm_ad_groupid }}
     {% endif %}
     {% if node.install.extra_parameters is defined and node.install.extra_parameters|length > 0 %}
       {% for key,value in node.install.extra_parameters.items() %}

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -6,6 +6,19 @@ include:
 
 {% for node in hana.nodes if node.host == host and node.install is defined %}
 
+# TODO:
+# 0) check with 
+
+# realmd list | grep active  -> this give dinamically if node is connected to AD
+
+
+#populate variable with ID and GID set dinamically by sssd
+# 1) get_id
+
+
+# 2) get_uid
+
+
 hana_install_{{ node.host+node.sid }}:
   hana.installed:
     - name: {{ node.sid }}
@@ -25,6 +38,10 @@ hana_install_{{ node.host+node.sid }}:
     {% endif %}
     - extra_parameters:
       - hostname: {{ node.host }}
+    {% if ad_connected is True %}
+      - userid:  {{node_ad_uid}}
+      - groupid: {{node_ad_groupid}}
+    {% endif %}
     {% if node.install.extra_parameters is defined and node.install.extra_parameters|length > 0 %}
       {% for key,value in node.install.extra_parameters.items() %}
       - {{ key }}: {{ value }}


### PR DESCRIPTION
So after an extensive research and readings on sap documentations etc (https://help.sap.com/doc/e9702d76c3284623b02de196c0e79e49/2.0.05/en-US/SAP_HANA_Server_Installation_Guide_en.pdf) 
I found out that even if the sapys is by default 79, this **doesn't** mean that users/auto-install cannot override it. 
Even if others upstream doc are stating this somehow not clearly.

anyways for us mean we **don't need unix/posix attributes on AD set**
 which is quite good and spare us lot of work and enable cloud integrations.



the pseudocode works ( I hardcoded the uid/id on a real scenario, after stopping states etc)
I might just need to adapt the salt code to get the `id prdadm` getting the ID dynamically and then pass them to the formula, and checking if the node is on ad.


I think for netweaver the same mechanism should exist for overriding this default parameters (didn;'t checked)