### PR TITLE
Use /usr/etc by default

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.6.0+git.%ct.%h</param>
+    <param name="versionformat">0.6.1+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -52,25 +52,12 @@ prometheus-hanadb_exporter:
   - require:
       - install_pydbapi_client
 
-hanadb_exporter_logging_configuration:
-  file.managed:
-    - name: /etc/hanadb_exporter/logging_config.ini
-    - source: /usr/etc/hanadb_exporter/logging_config.ini
-    - require:
-      - prometheus-hanadb_exporter
-
-hanadb_exporter_metrics_configuration:
-  file.managed:
-    - name: /etc/hanadb_exporter/metrics.json
-    - source: /usr/etc/hanadb_exporter/metrics.json
-    - require:
-      - prometheus-hanadb_exporter
 {% endif %}
 
 hanadb_exporter_configuration_{{ exporter_instance }}:
   file.managed:
     - source: salt://hana/templates/hanadb_exporter.j2
-    - name: /etc/hanadb_exporter/{{ exporter_instance }}.json
+    - name: /usr/etc/hanadb_exporter/{{ exporter_instance }}.json
     - template: jinja
     - require:
       - prometheus-hanadb_exporter

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -61,8 +61,6 @@ hanadb_exporter_configuration_{{ exporter_instance }}:
     - template: jinja
     - require:
       - prometheus-hanadb_exporter
-      - hanadb_exporter_metrics_configuration
-      - hanadb_exporter_logging_configuration
     - context:
         exporter: {{ exporter|yaml }}
         sap_instance_nr: "{{ sap_instance_nr }}"

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 22 13:38:47 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>
+
+- Version 0.6.1:
+  * Remove copy of config files for exporters since we use /usr/etc
+
+-------------------------------------------------------------------
 Thu Aug 20 02:00:46 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Version 0.6.0

--- a/templates/hanadb_exporter.j2
+++ b/templates/hanadb_exporter.j2
@@ -14,7 +14,7 @@
     "password": "{{ exporter.password }}"
   },
   "logging": {
-    "config_file": "/etc/hanadb_exporter/logging_config.ini",
+    "config_file": "/usr/etc/hanadb_exporter/logging_config.ini",
     "log_file": "/var/log/hanadb_exporter_{{ exporter_instance }}.log"
   }
 }


### PR DESCRIPTION
# DESC:

this pr change to use `/usr/etc` by default for configuration files.

I do think this is safe enough for all systems. All linux systems have that folder allthough isn't used.

https://github.com/SUSE/hanadb_exporter/pull/78

works