### PR TITLE
Change sap hana media extraction location 

### DIFF
--- a/hana/defaults.yaml
+++ b/hana/defaults.yaml
@@ -1,6 +1,6 @@
 hana:
   install_packages: true
   ha_enabled: true
-  hana_extract_dir: /sapmedia/HANA
+  hana_extract_dir: /sapmedia_extract/hana
   nodes: []
   monitoring_enabled: false

--- a/hana/defaults.yaml
+++ b/hana/defaults.yaml
@@ -1,6 +1,6 @@
 hana:
   install_packages: true
   ha_enabled: true
-  hana_extract_dir: /sapmedia_extract/hana
+  hana_extract_dir: /sapmedia_extract/HANA
   nodes: []
   monitoring_enabled: false

--- a/pillar.example
+++ b/pillar.example
@@ -14,9 +14,10 @@ hana:
   software_path: '/sapmedia/HANA/51052481'
   # Or specify the path to the hana installation media archive
   # If using hana sar archive, please also provide compatible version of sapcar executable
-  # The archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia_extract/hana)
+  # The archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia_extract/HANA)
+  # hana_extract_dir should be a new directory and seperate from location where the compressed files are present, to avoid conflicts in file permissions.
   hana_archive_file: '/sapmedia/51053492.ZIP'
-  hana_extract_dir: '/sapmedia_extract/hana'
+  hana_extract_dir: '/sapmedia_extract/HANA'
   #sapcar_exe_file: '/sapmedia/SAPCAR'
 
   # Enable HA cluster configuration. It installs the SAPHanaSR hook.

--- a/pillar.example
+++ b/pillar.example
@@ -14,9 +14,9 @@ hana:
   software_path: '/sapmedia/HANA/51052481'
   # Or specify the path to the hana installation media archive
   # If using hana sar archive, please also provide compatible version of sapcar executable
-  # The archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia/HANA)
+  # The archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia_extract/hana)
   hana_archive_file: '/sapmedia/51053492.ZIP'
-  hana_extract_dir: '/sapmedia/HANA'
+  hana_extract_dir: '/sapmedia_extract/hana'
   #sapcar_exe_file: '/sapmedia/SAPCAR'
 
   # Enable HA cluster configuration. It installs the SAPHanaSR hook.

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Sep 24 20:23:13 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Change the default 'hana_extract_dir' hana media extraction location
+
+-------------------------------------------------------------------
 Tue Sep 22 13:38:47 UTC 2020 - Dario Maiocchi <dmaiocchi@suse.com>
 
 - Version 0.6.1:


### PR DESCRIPTION
To avoid conflict with ready-only sap media mount points, we need to update the location where SAP HANA archives are extracted. Currently, both the default mounting point for sap media, and extraction path for sap media are same: `/sapmedia/HANA`
This can cause issues as mentioned by Peter Schinagl in
https://github.com/SUSE/ha-sap-terraform-deployments/pull/546

1) Could you suggest if there is a better naming for this extraction directory?
2) Based on my research, there is no restriction on where this location can be, except it has to have right permission. 

However, I think placing it under the `/hana` sub directories may not be a good idea. Considering that `/hana/data` `/hana/log`
may run out of disk space, and `/hana/shared/` being used as shared mount directory amongst the hana hosts, I am using a separate directory for hana extraction media.

To-do:
- Test with the installations
- Update the terraform project with this changes
- Follow up with same changes on Netweaver
