### PR TITLE
update Suse manager form and fix hana_extract_dir variable usage

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -104,8 +104,14 @@ hana:
         $visibleIf: .install_checkbox == true
         $optional: true
         $type: group
+        local_software_path_checkbox:
+          $name: Use local HANA installation media
+          $type: boolean
+          $default: false
+          $help: Specify the installation media on this node, otherwise global software path will be used.
         software_path:
           $name: Path to local HANA installation media
+          $visibleIf: .local_software_path_checkbox == true
           $type: text
           $optional: false
           $help: The path to already extracted HANA platform installation media folder which can be local or already mounted shared location (NFS, SMB, etc). This will have preference over global software path.

--- a/form.yml
+++ b/form.yml
@@ -6,6 +6,51 @@ hana:
     $type: boolean
     $default: true
     $help: Install all required packages from currently existing repositories
+  saptune_solution:
+    $name: saptune solution to apply
+    $type: text
+    $default: HANA
+    $help: saptune solution to apply to all nodes
+    $optional: true
+  software_path:
+    $name: Path to HANA platform installation media folder
+    $type: text
+    $help: The path to already extracted HANA platform installation media folder which can be local or already mounted shared location (NFS, SMB, etc). This will have preference over hana installation media archive
+    $optional: true
+  use_hana_archive_file:
+    $name: Use archive file for HANA platform installation 
+    $type: boolean
+    $default: false
+    $help: Mark this option if you want to use a hana archive file for the HANA installation
+  hana_archive_file:
+    $name: Path to HANA platform installation media archive
+    $visibleIf: .use_hana_archive_file == true
+    $type: text
+    $help: The path to installation media archive in any of the RAR, ZIP, EXE or SAR format. For SAR archive, please also provide the sapcar executable path for extraction
+    $optional: true
+  hana_extract_dir:
+    $name: Path to extract the HANA installation media archive
+    $visibleIf: .use_hana_archive_file == true
+    $type: text
+    $default: /sapmedia_extract/HANA
+    $help: The HANA archive will be extracted to this path. By default this path is /sapmedia_extract/HANA
+    $optional: true
+  sapcar_exe_file:
+    $name: Path to sapcar executable if extracting HANA SAR archive
+    $visibleIf: .use_hana_archive_file == true
+    $type: text
+    $help: The path to sapcar executable to extract HANA SAR archive
+    $optional: true
+  ha_enabled:
+    $name: Enable HA cluster configuration
+    $type: boolean
+    $default: true
+    $help: Enable the HA cluster configuration which will install the SAPHanaSR hook. To use this option the primary and secondary nodes must be defined in the pillar file
+  monitoring_enabled:
+    $name: Enable the host to be monitored by exporters
+    $type: boolean
+    $default: false
+    $help: Enable the node monitoring via exporters which will be installed and configured in all the nodes. Customize the exporter configuration in each node's dedicated sections.
   nodes:
     $name: Nodes
     $type: edit-group
@@ -60,10 +105,10 @@ hana:
         $optional: true
         $type: group
         software_path:
-          $name: Downloaded HANA software path
+          $name: Path to local HANA installation media
           $type: text
           $optional: false
-          $help: This is a local or already monted shared location (NFS, SMB, etc). The SAP HANA binaries must be already uncompressed
+          $help: The path to already extracted HANA platform installation media folder which can be local or already mounted shared location (NFS, SMB, etc). This will have preference over global software path.
         root_user:
           $name: Machine root user
           $type: text
@@ -82,6 +127,16 @@ hana:
           $visibleIf: .use_config_file == true
           $type: text
           $help: Path to the config file location. The template can be generated with the hdblcm --dump_configfile_template option
+        use_hdb_pwd_file:
+          $name: Fetch HANA passwords from XML file
+          $type: boolean
+          $default: false
+          $help: Mark this option if you want to fetch HANA passwords from XML file for the HANA installation options
+        hdb_pwd_file:
+          $name: Path to XML file with HANA Passwords
+          $visibleIf: .use_hdb_pwd_file == true
+          $type: text
+          $help: Path to the XML file location. The password template can be generated with the hdblcm --dump_configfile_template option        
         sapadm_password:
           $name: SAP admin password (<sid>adm)
           $visibleIf: .use_config_file == false

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -1,6 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
-{%- from "hana/extract_hana_package.sls" import hana_extract_dir with context -%}
 {% set host = grains['host'] %}
+{% set hana_extract_dir = hana.hana_extract_dir %}
 
 include:
     - .enable_cost_optimized

--- a/hana/pre_validation.sls
+++ b/hana/pre_validation.sls
@@ -4,7 +4,7 @@
 
 {# Check HANA archive media checkbox #}
 {% if hana.use_hana_archive_file is defined and hana.use_hana_archive_file == false %}
-    {% do hana.pop('hana_archive_file') %}
+    {% do hana.pop('hana_archive_file', none) %}
 {% endif %}
 
 {% for node in hana.nodes if node.host == host %}
@@ -17,6 +17,10 @@
   {% elif node.install_checkbox is defined and node.install_checkbox == true %}
     {% if node.install.use_config_file == false %}
       {% do node.install.pop('config_file') %}
+    {% endif %}
+
+    {% if node.install.local_software_path_checkbox == false %}
+      {% do node.install.pop('software_path') %}
     {% endif %}
 
     {% if node.install.use_hdb_pwd_file == false %}

--- a/hana/pre_validation.sls
+++ b/hana/pre_validation.sls
@@ -2,6 +2,11 @@
 
 {% set host = grains['host'] %}
 
+{# Check HANA archive media checkbox #}
+{% if hana.use_hana_archive_file is defined and hana.use_hana_archive_file == false %}
+    {% do hana.pop('hana_archive_file') %}
+{% endif %}
+
 {% for node in hana.nodes if node.host == host %}
 
   {# Check HANA install checkbox #}
@@ -12,6 +17,10 @@
   {% elif node.install_checkbox is defined and node.install_checkbox == true %}
     {% if node.install.use_config_file == false %}
       {% do node.install.pop('config_file') %}
+    {% endif %}
+
+    {% if node.install.use_hdb_pwd_file == false %}
+      {% do node.install.pop('hdb_pwd_file') %}
     {% endif %}
 
     {% if node.install.extra_parameters is defined and node.install.extra_parameters|length > 0 and node.install.extra_parameters is not mapping %}

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sat Oct  3 04:59:38 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Update sumaform and pre validation state with latest changes in formula 
+
+-------------------------------------------------------------------
 Thu Sep 24 20:23:13 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Change the default 'hana_extract_dir' hana media extraction location

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Sat Oct  3 04:59:38 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
-- Update sumaform and pre validation state with latest changes in formula 
+- Update SUMA form.yml file and prevalidation state with latest changes in formula 
 
 -------------------------------------------------------------------
 Thu Sep 24 20:23:13 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>


### PR DESCRIPTION
1) Update suma form with new entries mainly related to:
- saptune
- ha cluster states
- hana media extraction logic
- hdb password xml file
- monitoring
- fix for hana installation media preference in the form (this matches the actual usage in pillar )

2) Update how the `hana_extract_dir`  is  imported/used in hana media extraction states
3) Update pre validation logic

This PR replaces https://github.com/SUSE/saphanabootstrap-formula/pull/90

Tested with Suse manager `4.1`  web interface and highstates