### PR TITLE
Workaround for installation when using exe archive

### DIFF
--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -1,16 +1,8 @@
 {%- from "hana/map.jinja" import hana with context -%}
+{%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
+{% set hana_extract_dir = get_hana_exe_extract_dir(hana) %}
 
 {% set host = grains['host'] %}
-{% set hana_extract_dir = hana.hana_extract_dir %}
-
-# Below is temporary workaround to update the software installation path when using unrar for HANA multipart rar archive
-# TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive
-# Below logic finds the extraction location based on name of multipart exe archive filename
-{%- if hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".exe", ".EXE")) %}
-{% set archive_base_name = salt['file.basename']( hana.hana_archive_file.split('.')[0]) %}
-{% set archive_name = archive_base_name.split('_')[0] %}
-{% set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
-{% endif %}
 
 {% for node in hana.nodes %}
 {% if node.host == host and node.scenario_type is defined and node.scenario_type.lower() == 'cost-optimized' and node.cost_optimized_parameters is defined%}

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -1,7 +1,16 @@
 {%- from "hana/map.jinja" import hana with context -%}
-{%- from "hana/extract_hana_package.sls" import hana_extract_dir with context -%}
 
 {% set host = grains['host'] %}
+{% set hana_extract_dir = hana.hana_extract_dir %}
+
+# Below is temporary workaround to update the software installation path when using unrar for HANA multipart rar archive
+# TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive
+# Below logic finds the extraction location based on name of multipart exe archive filename
+{%- if hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".exe", ".EXE")) %}
+{% set archive_base_name = salt['file.basename']( hana.hana_archive_file.split('.')[0]) %}
+{% set archive_name = archive_base_name.split('_')[0] %}
+{% set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
+{% endif %}
 
 {% for node in hana.nodes %}
 {% if node.host == host and node.scenario_type is defined and node.scenario_type.lower() == 'cost-optimized' and node.cost_optimized_parameters is defined%}

--- a/hana/extract_hana_package.sls
+++ b/hana/extract_hana_package.sls
@@ -25,18 +25,13 @@ install_unrar_package:
   pkg.installed:
     - name: {{ unrar_package }}
 
+# unrar tool does not have the option to skip extracting top-level directory when using multipart exe archives#
 extract_hana_multipart_archive:
   cmd.run:
     - name: unrar x {{ hana_package }}
     - cwd: {{ hana_extract_dir }}
     - require:
         - install_unrar_package
-
-{# Below is temporary workaround to update the extraction path when using unrar for multipart rar archive#}
-{# TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive#}
-{% set archive_base_name = salt['file.basename'](hana_package.split('.')[0]) %}
-{% set archive_name = archive_base_name.split('_')[0] %}
-{% set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
 
 {%- elif hana_package.endswith((".sar", ".SAR")) and hana.sapcar_exe_file is defined %}
 

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -2,6 +2,15 @@
 {% set host = grains['host'] %}
 {% set hana_extract_dir = hana.hana_extract_dir %}
 
+# Below is temporary workaround to update the software installation path when using unrar for HANA multipart rar archive#
+# TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive
+# Below logic finds the extraction location based on name of multipart exe archive filename
+{%- if hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".exe", ".EXE")) %}
+{% set archive_base_name = salt['file.basename']( hana.hana_archive_file.split('.')[0]) %}
+{% set archive_name = archive_base_name.split('_')[0] %}
+{% set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
+{% endif %}
+
 include:
     - .enable_cost_optimized
 

--- a/hana/install.sls
+++ b/hana/install.sls
@@ -1,15 +1,7 @@
 {%- from "hana/map.jinja" import hana with context -%}
+{%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
 {% set host = grains['host'] %}
-{% set hana_extract_dir = hana.hana_extract_dir %}
-
-# Below is temporary workaround to update the software installation path when using unrar for HANA multipart rar archive#
-# TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive
-# Below logic finds the extraction location based on name of multipart exe archive filename
-{%- if hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".exe", ".EXE")) %}
-{% set archive_base_name = salt['file.basename']( hana.hana_archive_file.split('.')[0]) %}
-{% set archive_name = archive_base_name.split('_')[0] %}
-{% set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
-{% endif %}
+{% set hana_extract_dir = get_hana_exe_extract_dir(hana) %}
 
 include:
     - .enable_cost_optimized

--- a/hana/macros/get_hana_exe_extract_dir.sls
+++ b/hana/macros/get_hana_exe_extract_dir.sls
@@ -1,0 +1,12 @@
+{% macro get_hana_exe_extract_dir(hana) -%}
+{%- set hana_extract_dir = hana.hana_extract_dir %}
+    {#- Below is temporary workaround to update the software installation path when using unrar for HANA multipart rar archive#}
+    {#- TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive#}
+    {#- Below logic finds the extraction location based on name of multipart exe archive filename#}
+    {%- if hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".exe", ".EXE")) %}
+    {%- set archive_base_name = salt['file.basename']( hana.hana_archive_file.split('.')[0]) %}
+    {%- set archive_name = archive_base_name.split('_')[0] %}
+    {%- set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
+    {%- endif %}
+{{- hana_extract_dir }}
+{%- endmacro %}

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,7 +1,16 @@
 {%- from "hana/map.jinja" import hana with context -%}
-{%- from "hana/extract_hana_package.sls" import hana_extract_dir with context -%}
 
 {% set pydbapi_output_dir = '/tmp/pydbapi' %}
+{% set hana_extract_dir = hana.hana_extract_dir %}
+
+# Below is temporary workaround to update the software path when using unrar for HANA multipart rar archive
+# TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive
+# Below logic finds the extraction location based on name of multipart exe archive filename
+{%- if hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".exe", ".EXE")) %}
+{% set archive_base_name = salt['file.basename']( hana.hana_archive_file.split('.')[0]) %}
+{% set archive_name = archive_base_name.split('_')[0] %}
+{% set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
+{% endif %}
 
 {% for node in hana.nodes if node.host == grains['host'] %}
 

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,16 +1,8 @@
 {%- from "hana/map.jinja" import hana with context -%}
+{%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
+{% set hana_extract_dir = get_hana_exe_extract_dir(hana) %}
 
 {% set pydbapi_output_dir = '/tmp/pydbapi' %}
-{% set hana_extract_dir = hana.hana_extract_dir %}
-
-# Below is temporary workaround to update the software path when using unrar for HANA multipart rar archive
-# TODO: Find better solution to set or detect the correct extraction path when extracting multipart rar archive
-# Below logic finds the extraction location based on name of multipart exe archive filename
-{%- if hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".exe", ".EXE")) %}
-{% set archive_base_name = salt['file.basename']( hana.hana_archive_file.split('.')[0]) %}
-{% set archive_name = archive_base_name.split('_')[0] %}
-{% set hana_extract_dir = hana_extract_dir| path_join(archive_name) %}
-{% endif %}
 
 {% for node in hana.nodes if node.host == grains['host'] %}
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Sun Oct 11 04:21:32 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Fix the hana media extraction and installation logics when using exe archives 
+
+-------------------------------------------------------------------
 Thu Oct  8 02:34:37 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Update the SUMA hana form metadata, to show hana form under SAP deployment group 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Oct  6 21:36:18 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Fix the hana media extraction and installation logic when using exe archives  
+
+-------------------------------------------------------------------
 Sat Oct  3 04:59:38 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Update SUMA form.yml file and prevalidation state with latest changes in formula 

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -36,7 +36,6 @@ Suggests:       prometheus-hanadb_exporter >= 0.7.0
 %define fname hana
 %define fdir  %{_datadir}/salt-formulas
 %define ftemplates templates
-%define fmacros macros
 
 %description
 SAP HANA deployment salt formula. This formula is capable to install
@@ -77,7 +76,6 @@ fi
 
 %attr(0755, root, salt) %{fdir}/states/%{fname}
 %attr(0755, root, salt) %{fdir}/states/%{fname}/%{ftemplates}
-%attr(0755, root, salt) %{fdir}/states/%{fname}/%{fmacros}
 %attr(0755, root, salt) %{fdir}/metadata/%{fname}
 
 %changelog

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -36,6 +36,7 @@ Suggests:       prometheus-hanadb_exporter >= 0.7.0
 %define fname hana
 %define fdir  %{_datadir}/salt-formulas
 %define ftemplates templates
+%define fmacros macros
 
 %description
 SAP HANA deployment salt formula. This formula is capable to install
@@ -76,6 +77,7 @@ fi
 
 %attr(0755, root, salt) %{fdir}/states/%{fname}
 %attr(0755, root, salt) %{fdir}/states/%{fname}/%{ftemplates}
+%attr(0755, root, salt) %{fdir}/states/%{fname}/%{fmacros}
 %attr(0755, root, salt) %{fdir}/metadata/%{fname}
 
 %changelog


### PR DESCRIPTION
The underlying problem:

Using the `unrar`/ `unar` packages to extract multipart rar archives... did not support/work for extraction with top-level directory skipping.
Saltstack rar extraction functions did not work as well.
For example: `51053381_part1.exe`  `51053381_part2.rar` .. multipart archives will extract to a directory named `51053381` under location we specify, and not directly to specified output directory.
This becomes problem when we want to tell the installer where hana media is located.
The hana installer needs to know this folder name (as part of complete software path) which contains the `LABEL.asc` file.

Workaround:

I did the jinja workaround logic to find /calculate the folder name, from the name of archive itself, and append it to path, which was working fine, until recent change https://github.com/SUSE/saphanabootstrap-formula/commit/5f5b87fcaa2033cf0da7a513d7289b327578f1d4

Current workaround:

I updated the logic in install, monitoring, cost-opt states, to avoid importing variables from extraction sls file(which is problem when using with SUMA highstate)  and moved the  folder name workaround logic to these states.

Tested with Azure deployment using exe archive media.

