### PR TITLE
Update the SUMA metadata to show hana form under SAP deployment group

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -1,4 +1,4 @@
 description:
   SAP HANA deployment formula
 group:
-  SAP HANA deployment
+  SAP deployment

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct  8 02:34:37 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Update the SUMA hana form metadata, to show hana form under SAP deployment group 
+
+-------------------------------------------------------------------
 Sat Oct  3 04:59:38 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Update SUMA form.yml file and prevalidation state with latest changes in formula 


### PR DESCRIPTION
With this change, both SAP HANA and NW formulas will show under the SAP deployment group, under the SUMA formulas list

![image](https://user-images.githubusercontent.com/8645166/95408574-a177bd00-08d4-11eb-86e0-93ed19da7f1e.png)
