### PR TITLE
HANA client SAR archive extraction

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.6.3+git.%ct.%h</param>
+    <param name="versionformat">0.6.2+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.6.2+git.%ct.%h</param>
+    <param name="versionformat">0.6.3+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/hana/defaults.yaml
+++ b/hana/defaults.yaml
@@ -2,5 +2,6 @@ hana:
   install_packages: true
   ha_enabled: true
   hana_extract_dir: /sapmedia_extract/HANA
+  client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
   nodes: []
   monitoring_enabled: false

--- a/hana/defaults.yaml
+++ b/hana/defaults.yaml
@@ -2,6 +2,6 @@ hana:
   install_packages: true
   ha_enabled: true
   hana_extract_dir: /sapmedia_extract/HANA
-  hana_client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
+  hana_client_extract_dir: /sapmedia_extract/HANA_CLIENT
   nodes: []
   monitoring_enabled: false

--- a/hana/defaults.yaml
+++ b/hana/defaults.yaml
@@ -2,6 +2,6 @@ hana:
   install_packages: true
   ha_enabled: true
   hana_extract_dir: /sapmedia_extract/HANA
-  client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
+  hana_client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
   nodes: []
   monitoring_enabled: false

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -1,6 +1,10 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{% set hana_extract_dir = get_hana_exe_extract_dir(hana) %}
+{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR") %}
+{%- set hana_client_path = hana.client_extract_dir %}
+{%- else %}
+{%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
+{%- endif %}
 
 {% set host = grains['host'] %}
 
@@ -56,7 +60,7 @@ failure:
 extract_hana_pydbapi_archive:
     hana.pydbapi_extracted:
       - name: PYDBAPI.TGZ
-      - software_folders: [{{ node.install.software_path|default(hana.software_path)|default(hana_extract_dir) }}]
+      - software_folders: [{{ node.install.software_path|default(hana.software_path)|default(hana_client_path) }}]
       - output_dir: /hana/shared/srHook
       - hana_version: '20'
       - force: true

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -1,6 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
+{%- if hana.client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
 {%- set hana_client_path = hana.client_extract_dir %}
 {%- else %}
 {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -1,7 +1,8 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{%- if hana.client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
-{%- set hana_client_path = hana.client_extract_dir %}
+# If hana archive used for installation is sar format, it will not contain the hana client, so we need to use a hana client archive
+{%- if hana.hana_client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
+{%- set hana_client_path = hana.hana_client_extract_dir %}
 {%- else %}
 {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
 {%- endif %}

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -1,6 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR") %}
+{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
 {%- set hana_client_path = hana.client_extract_dir %}
 {%- else %}
 {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}

--- a/hana/enable_cost_optimized.sls
+++ b/hana/enable_cost_optimized.sls
@@ -1,11 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
-{%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-# If hana archive used for installation is sar format, it will not contain the hana client, so we need to use a hana client archive
-{%- if hana.hana_client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
-{%- set hana_client_path = hana.hana_client_extract_dir %}
-{%- else %}
-{%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
-{%- endif %}
+{%- from 'hana/macros/get_hana_client_path.sls' import get_hana_client_path with context %}
+{%- set hana_client_path = get_hana_client_path(hana) %}
 
 {% set host = grains['host'] %}
 

--- a/hana/extract_hana_package.sls
+++ b/hana/extract_hana_package.sls
@@ -51,10 +51,10 @@ copy_signature_file_to_installer_dir:
     - require:
         - extract_hdbserver_sar_archive
 
-{%- if hana.client_archive_file is defined and hana.client_archive_file.endswith((".sar", ".SAR")) %}
+{%- if hana.hana_client_archive_file is defined and hana.hana_client_archive_file.endswith((".sar", ".SAR")) %}
 extract_hana_client_sar_archive:
   sapcar.extracted:
-    - name: {{ hana.client_archive_file }}
+    - name: {{ hana.hana_client_archive_file }}
     - sapcar_exe: {{ hana.sapcar_exe_file }}
     - output_dir: {{ hana_client_extract_dir }}
     - options: "-manifest SIGNATURE.SMF"

--- a/hana/extract_hana_package.sls
+++ b/hana/extract_hana_package.sls
@@ -56,7 +56,7 @@ extract_hana_client_sar_archive:
   sapcar.extracted:
     - name: {{ hana.hana_client_archive_file }}
     - sapcar_exe: {{ hana.sapcar_exe_file }}
-    - output_dir: {{ hana_client_extract_dir }}
+    - output_dir: {{ hana.hana_client_extract_dir }}
     - options: "-manifest SIGNATURE.SMF"
 {% endif %}
 

--- a/hana/extract_hana_package.sls
+++ b/hana/extract_hana_package.sls
@@ -51,5 +51,14 @@ copy_signature_file_to_installer_dir:
     - require:
         - extract_hdbserver_sar_archive
 
+{%- if hana.client_archive_file is defined and hana.client_archive_file.endswith((".sar", ".SAR")) %}
+extract_hana_client_sar_archive:
+  sapcar.extracted:
+    - name: {{ hana.client_archive_file }}
+    - sapcar_exe: {{ hana.sapcar_exe_file }}
+    - output_dir: {{ hana_client_extract_dir }}
+    - options: "-manifest SIGNATURE.SMF"
+{% endif %}
+
 {%- endif %}
 {%- endif %}

--- a/hana/macros/get_hana_client_path.sls
+++ b/hana/macros/get_hana_client_path.sls
@@ -1,0 +1,13 @@
+{% macro get_hana_client_path(hana) -%}
+{%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
+    {#- If hana archive used for installation is sar format, it will not contain the hana client, so we need to provide a hana client #}
+    {#- One of the following paths is used for hana client based on pillar entries: 1. hana_client_software_path 2. hana_client_extract_dir 3. hana_extract_dir #}
+    {%- if hana.hana_client_software_path is defined %}
+    {%- set hana_client_path = hana.hana_client_software_path %}
+    {%- elif hana.hana_client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
+    {%- set hana_client_path = hana.hana_client_extract_dir %}
+    {%- else %}
+    {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
+    {%- endif %}
+{{- hana_client_path }}
+{%- endmacro %}

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,6 +1,10 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{% set hana_extract_dir = get_hana_exe_extract_dir(hana) %}
+{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR") %}
+{%- set hana_client_path = hana.client_extract_dir %}
+{%- else %}
+{%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
+{%- endif %}
 
 {% set pydbapi_output_dir = '/tmp/pydbapi' %}
 
@@ -31,7 +35,7 @@ install_python_pip:
 extract_pydbapi_client:
   hana.pydbapi_extracted:
     - name: PYDBAPI.TGZ
-    - software_folders: [{{ exporter.hana_client_path|default(node.install.software_path)|default(hana.software_path)|default(hana_extract_dir) }}]
+    - software_folders: [{{ exporter.hana_client_path|default(node.install.software_path)|default(hana.software_path)|default(hana_client_path) }}]
     - output_dir: {{ pydbapi_output_dir }}
     - hana_version: '20'
     - force: true

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,6 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
+{%- if hana.client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
 {%- set hana_client_path = hana.client_extract_dir %}
 {%- else %}
 {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,11 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
-{%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-# If hana archive used for installation is sar format, it will not contain the hana client, so we need to use a hana client archive
-{%- if hana.hana_client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
-{%- set hana_client_path = hana.hana_client_extract_dir %}
-{%- else %}
-{%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
-{%- endif %}
+{%- from 'hana/macros/get_hana_client_path.sls' import get_hana_client_path with context %}
+{%- set hana_client_path = get_hana_client_path(hana) %}
 
 {% set pydbapi_output_dir = '/tmp/pydbapi' %}
 
@@ -36,7 +31,7 @@ install_python_pip:
 extract_pydbapi_client:
   hana.pydbapi_extracted:
     - name: PYDBAPI.TGZ
-    - software_folders: [{{ exporter.hana_client_path|default(node.install.software_path)|default(hana.software_path)|default(hana_client_path) }}]
+    - software_folders: [{{ node.install.software_path|default(hana.software_path)|default(hana_client_path) }}]
     - output_dir: {{ pydbapi_output_dir }}
     - hana_version: '20'
     - force: true

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,7 +1,8 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{%- if hana.client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
-{%- set hana_client_path = hana.client_extract_dir %}
+# If hana archive used for installation is sar format, it will not contain the hana client, so we need to use a hana client archive
+{%- if hana.hana_client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
+{%- set hana_client_path = hana.hana_client_extract_dir %}
 {%- else %}
 {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
 {%- endif %}

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,6 +1,6 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
-{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR") %}
+{%- if hana.client_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
 {%- set hana_client_path = hana.client_extract_dir %}
 {%- else %}
 {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}

--- a/pillar.example
+++ b/pillar.example
@@ -19,8 +19,8 @@ hana:
   hana_archive_file: '/sapmedia/51053492.ZIP'
   hana_extract_dir: '/sapmedia_extract/HANA'
   # The HANA Client sar archive is needed for monitoring if HANA DB sar archive is provided. It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
-  client_archive_file: '/sapmedia/IMDB_CLIENT20_003_144-80002090.SAR'
-  client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
+  hana_client_archive_file: '/sapmedia/IMDB_CLIENT20_003_144-80002090.SAR'
+  hana_client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
   #sapcar_exe_file: '/sapmedia/SAPCAR'
 
   # Enable HA cluster configuration. It installs the SAPHanaSR hook.

--- a/pillar.example
+++ b/pillar.example
@@ -18,6 +18,9 @@ hana:
   # hana_extract_dir should be a new directory and seperate from location where the compressed files are present, to avoid conflicts in file permissions.
   hana_archive_file: '/sapmedia/51053492.ZIP'
   hana_extract_dir: '/sapmedia_extract/HANA'
+  # The HANA Client sar archive is needed for monitoring if HANA DB sar archive is provided. It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
+  client_archive_file: '/sapmedia/IMDB_CLIENT20_003_144-80002090.SAR'
+  client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
   #sapcar_exe_file: '/sapmedia/SAPCAR'
 
   # Enable HA cluster configuration. It installs the SAPHanaSR hook.

--- a/pillar.example
+++ b/pillar.example
@@ -9,18 +9,25 @@ hana:
   # Warning: only a unique solution can exist into a node.
   saptune_solution: 'HANA'
 
-  # Specify the path to already extracted HANA platform installation media
-  # This will have preference over hana installation media archive
+  # HANA installation media can be provided in one of the two methods: extracted HANA platform folder or HANA media archive
+  # 1. Path to already extracted HANA platform installation media. This will have preference over hana installation media archive
   software_path: '/sapmedia/HANA/51052481'
-  # Or specify the path to the hana installation media archive
+  # 2. Or specify the path to the hana installation media archive
   # If using hana sar archive, please also provide compatible version of sapcar executable
   # The archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia_extract/HANA)
   # hana_extract_dir should be a new directory and seperate from location where the compressed files are present, to avoid conflicts in file permissions.
   hana_archive_file: '/sapmedia/51053492.ZIP'
   hana_extract_dir: '/sapmedia_extract/HANA'
-  # The HANA Client sar archive is needed for monitoring if HANA DB sar archive is provided. It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
+  
+  # HANA Client packages are needed for monitoring & cost-optimized scenario. HANA Client is already included in HANA platform media unless a HANA database sar archive is used 
+  # If the HANA archive used for installation is sar format specified above, you need to provide HANA Client in one of the two ways: extracted HANA client folder or HANA client sar archive file
+  # 1. Path to already extracted hana client folder
+  #hana_client_software_path: '/sapmedia/IMDB_CLIENT'
+  # 2. Or specify the path to the hana client sar archive file. It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
   hana_client_archive_file: '/sapmedia/IMDB_CLIENT20_003_144-80002090.SAR'
   hana_client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
+  
+  #If using a sar archive for hana platform or hana client media, please provide compatible version of sapcar executable
   #sapcar_exe_file: '/sapmedia/SAPCAR'
 
   # Enable HA cluster configuration. It installs the SAPHanaSR hook.
@@ -41,7 +48,7 @@ hana:
         # Specify the path to local installation media here, otherwise global variable software_path will be used for installation media.
         # If both of these paths are not set, hana_extract_dir path will be used for installation media,
         # given that hana_archive_file package is also provided
-        software_path: '/sapmedia/HANA/51052481'
+        #software_path: '/sapmedia/HANA/51052481'
         root_user: 'root'
         root_password: 's'
         # Fetch HANA passwords from XML file
@@ -74,8 +81,6 @@ hana:
         password: 'Qwerty1234'
         #port: 30015 # HANA database port. If multi_tenant is set this value is 3XX13 by default where XX is the instance number
         timeout: 600 # Timeout in seconds to start the connection with HANA database
-        # Set the path of the HANA Client folder, if it is not set, the node software_path will be used
-        #hana_client_path: /hana_client_path
 
     - host: 'hana02'
       sid: 'prd'

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 11 04:25:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Version 0.6.3
+ * Add support to extract and install HANA Client sar packages
+
+-------------------------------------------------------------------
 Mon Oct 19 14:48:50 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
 - Set the native fence mechanism usage for CSP as optional 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,8 +1,7 @@
 -------------------------------------------------------------------
 Wed Nov 11 04:25:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
-- Version 0.6.3
- * Add support to extract and install HANA Client sar packages
+- Add support to extract and install HANA Client sar packages
 
 -------------------------------------------------------------------
 Mon Oct 19 14:48:50 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>


### PR DESCRIPTION
With respect to: https://github.com/SUSE/ha-sap-terraform-deployments/issues/558

I have added the option to install HANA Client packages from SAR file for monitoring, cost-optimized HANA.  This is needed if the HANA database is installed using a SAR file where the client is not present.
This option works when you are using HANA DB archive SAR file only. In other cases, HANA platform folder or package will already have the HANA client.

There are 3 options now to use HANA Client. Below is their preference order:
1) HANA platform folder/archives (except hana db sar archive)- HANA client already included with this. So no additional parameters required for this option
2) Extracted hana client folder provided via variable: `hana_client_software_path` 
3) HANA Client sar file provided via variable: `hana_client_archive_file`  

Some additional changes with this PR:
- Remove node specific hana_client option in the exporter entry from pillar
- Update pillar example description for hana media archives

Test with deployments in libvirt using the above options