### PR TITLE
Abort formula execution if the SAP HANA installation fails

### DIFF
--- a/hana/enable_primary.sls
+++ b/hana/enable_primary.sls
@@ -27,5 +27,7 @@
         - database: {{ node.primary.backup.database }}
         - file: {{ node.primary.backup.file }}
       {% endif %}
+      - require:
+        - hana_install_{{ node.host+node.sid }}
 
 {% endfor %}

--- a/hana/enable_secondary.sls
+++ b/hana/enable_secondary.sls
@@ -31,6 +31,7 @@
     - timeout: {{ node.secondary.primary_timeout|default(100) }}
     - interval: {{ node.secondary.interval|default(10) }}
     - primary_pass: {{ password.primary }}
-
+    - require:
+      - hana_install_{{ node.host+node.sid }}
 
 {% endfor %}

--- a/hana/ha_cluster.sls
+++ b/hana/ha_cluster.sls
@@ -54,6 +54,8 @@ sudoers_backup_{{ sap_instance }}:
     - name: {{ tmp_sudoers }}
     - source: {{ sudoers }}
     - unless: cat {{ sudoers }} | grep {{ node.sid }}adm
+    - require:
+      - stop_hana_{{ sap_instance }}
 
 sudoers_append_{{ sap_instance }}:
   file.append:

--- a/hana/ha_cluster.sls
+++ b/hana/ha_cluster.sls
@@ -13,8 +13,8 @@ stop_hana_{{ sap_instance }}:
       - sid: {{ node.sid }}
       - inst: {{ node.instance }}
       - password: {{ node.password }}
-      - require:
-        - hana_install_{{ node.host+node.sid }}
+    - require:
+      - hana_install_{{ node.host+node.sid }}
 
 # Add SAPHANASR hook
 # It would be better to get the text from /usr/share/SAPHanaSR/samples/global.ini

--- a/hana/ha_cluster.sls
+++ b/hana/ha_cluster.sls
@@ -13,6 +13,8 @@ stop_hana_{{ sap_instance }}:
       - sid: {{ node.sid }}
       - inst: {{ node.instance }}
       - password: {{ node.password }}
+      - require:
+        - hana_install_{{ node.host+node.sid }}
 
 # Add SAPHANASR hook
 # It would be better to get the text from /usr/share/SAPHanaSR/samples/global.ini

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -27,6 +27,8 @@ install_python_pip:
         attempts: 3
         interval: 15
     - resolve_capabilities: true
+    - require:
+      - hana_install_{{ node.host+node.sid }}
 
 extract_pydbapi_client:
   hana.pydbapi_extracted:
@@ -35,6 +37,8 @@ extract_pydbapi_client:
     - output_dir: {{ pydbapi_output_dir }}
     - hana_version: '20'
     - force: true
+    - require:
+      - hana_install_{{ node.host+node.sid }}
 
 # pip.installed cannot manage file names with regular expressions
 # TODO: Improve this to use pip.installed somehow

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Nov 24 04:08:55 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Add requisite of hana installation to subsequent salt states 
+
+-------------------------------------------------------------------
 Wed Nov 11 04:25:03 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Add support to extract and install HANA Client sar packages


### PR DESCRIPTION
If the HANA installation fails, the subsequent states do not have to be executed. Right now, I have added the `require` statement to states following the HANA installation, and this will stop further salt states from execution

The overall runtime of salt execution after the failure, is now reduced. I have tested with deployments.
Note that some states like monitoring(grafana, loki) etc are executed from terraform project, and still get executed.
