### PR TITLE
Start the saptune systemd service after saptune solution is applied

### DIFF
--- a/hana/saptune.sls
+++ b/hana/saptune.sls
@@ -11,4 +11,8 @@ apply_saptune_solution_{{ host }}_{{ name }}:
   saptune.solution_applied:
     - name: {{ saptune_solution }}
 
+start_saptune_daemon_{{ host }}_{{ name }}:
+  cmd.run:
+    - name: saptune daemon start
+
 {% endfor %}

--- a/hana/saptune.sls
+++ b/hana/saptune.sls
@@ -11,7 +11,8 @@ apply_saptune_solution_{{ host }}_{{ name }}:
   saptune.solution_applied:
     - name: {{ saptune_solution }}
 
-start_saptune_daemon_{{ host }}_{{ name }}:
+# Start the saptune systemd service to ensure the system is well-tuned after a system reboot
+start_saptune_service_{{ host }}_{{ name }}:
   cmd.run:
     - name: saptune daemon start
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Dec  2 17:48:05 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
+
+- Start the saptune daemon service 
+
+-------------------------------------------------------------------
 Tue Nov 24 04:08:55 UTC 2020 - Simranpal Singh <simranpal.singh@suse.com>
 
 - Add requisite of hana installation to subsequent salt states 


### PR DESCRIPTION
Currently, the deployment doesn't start the saptune daemon. It is needed to get the sap tuning back especially after system reboot.
I have added the `saptune daemon start` cmd. which will be available in saptune version 3, but internally mapped to the new command `saptune service start`

Resolves the `ERROR: The parameters listed above have deviated from SAP/SUSE recommendations.`
