### PR TITLE
Fix hana client preference usage to use first the defined client method

### DIFF
--- a/hana/extract_hana_package.sls
+++ b/hana/extract_hana_package.sls
@@ -51,7 +51,10 @@ copy_signature_file_to_installer_dir:
     - require:
         - extract_hdbserver_sar_archive
 
-{%- if hana.hana_client_archive_file is defined and hana.hana_client_archive_file.endswith((".sar", ".SAR")) %}
+{%- endif %}
+{%- endif %}
+
+{%- if hana.hana_client_archive_file is defined and hana.hana_client_archive_file.endswith((".sar", ".SAR")) and hana.sapcar_exe_file is defined %}
 extract_hana_client_sar_archive:
   sapcar.extracted:
     - name: {{ hana.hana_client_archive_file }}
@@ -59,6 +62,3 @@ extract_hana_client_sar_archive:
     - output_dir: {{ hana.hana_client_extract_dir }}
     - options: "-manifest SIGNATURE.SMF"
 {% endif %}
-
-{%- endif %}
-{%- endif %}

--- a/hana/macros/get_hana_client_path.sls
+++ b/hana/macros/get_hana_client_path.sls
@@ -1,13 +1,15 @@
-{% macro get_hana_client_path(hana) -%}
+{% macro get_hana_client_path(hana, node) -%}
 {%- from 'hana/macros/get_hana_exe_extract_dir.sls' import get_hana_exe_extract_dir with context %}
     {#- If hana archive used for installation is sar format, it will not contain the hana client, so we need to provide a hana client #}
     {#- One of the following paths is used for hana client based on pillar entries: 1. hana_client_software_path 2. hana_client_extract_dir 3. hana_extract_dir #}
     {%- if hana.hana_client_software_path is defined %}
     {%- set hana_client_path = hana.hana_client_software_path %}
-    {%- elif hana.hana_client_archive_file is defined and hana.hana_archive_file is defined and hana.hana_archive_file.endswith((".sar", ".SAR")) %}
+    {%- elif hana.hana_client_archive_file is defined %}
     {%- set hana_client_path = hana.hana_client_extract_dir %}
-    {%- else %}
+    {%- elif hana.hana_archive_file is defined %}
     {%- set hana_client_path = get_hana_exe_extract_dir(hana) %}
+    {%- else %}
+    {%- set hana_client_path = node.install.software_path|default(hana.software_path) %}
     {%- endif %}
 {{- hana_client_path }}
 {%- endmacro %}

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -1,10 +1,10 @@
 {%- from "hana/map.jinja" import hana with context -%}
 {%- from 'hana/macros/get_hana_client_path.sls' import get_hana_client_path with context %}
-{%- set hana_client_path = get_hana_client_path(hana) %}
 
 {% set pydbapi_output_dir = '/tmp/pydbapi' %}
 
 {% for node in hana.nodes if node.host == grains['host'] %}
+{%- set hana_client_path = get_hana_client_path(hana, node) %}
 
 # if we have a replicated setup we only take exporter configuration from the primary
 {% if node.secondary is not defined %}
@@ -33,7 +33,7 @@ install_python_pip:
 extract_pydbapi_client:
   hana.pydbapi_extracted:
     - name: PYDBAPI.TGZ
-    - software_folders: [{{ node.install.software_path|default(hana.software_path)|default(hana_client_path) }}]
+    - software_folders: [{{ hana_client_path }}]
     - output_dir: {{ pydbapi_output_dir }}
     - hana_version: '20'
     - force: true

--- a/pillar.example
+++ b/pillar.example
@@ -10,23 +10,25 @@ hana:
   saptune_solution: 'HANA'
 
   # HANA installation media can be provided in one of the two methods: extracted HANA platform folder or HANA media archive
-  # 1. Path to already extracted HANA platform installation media. This will have preference over hana installation media archive
+  # 1. Path to an already extracted HANA platform installation media. This will have preference over hana installation media archive
   software_path: '/sapmedia/HANA/51052481'
   # 2. Or specify the path to the hana installation media archive
   # If using hana sar archive, please also provide compatible version of sapcar executable
   # The archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia_extract/HANA)
-  # hana_extract_dir should be a new directory and seperate from location where the compressed files are present, to avoid conflicts in file permissions.
+  # hana_extract_dir should be a new directory and separated from the location where the compressed files are present, to avoid conflicts in file permissions.
   hana_archive_file: '/sapmedia/51053492.ZIP'
   hana_extract_dir: '/sapmedia_extract/HANA'
-  
-  # HANA Client packages are needed for monitoring & cost-optimized scenario. HANA Client is already included in HANA platform media unless a HANA database sar archive is used 
+
+  # HANA Client packages are needed for monitoring & cost-optimized scenario. HANA Client is already included in HANA platform media unless a HANA database sar archive is used
   # If the HANA archive used for installation is sar format specified above, you need to provide HANA Client in one of the two ways: extracted HANA client folder or HANA client sar archive file
+  # If any of the next two options are used, this HANA Client will have preference over the HANA Client coming in the HANA platform described above. If HANA platform is used, it is usually better to
+  # not use the HANA Client as it might bring some compatibility issue.
   # 1. Path to already extracted hana client folder
   #hana_client_software_path: '/sapmedia/IMDB_CLIENT'
   # 2. Or specify the path to the hana client sar archive file. It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
   hana_client_archive_file: '/sapmedia/IMDB_CLIENT20_003_144-80002090.SAR'
   hana_client_extract_dir: '/sapmedia_extract/HANA_CLIENT'
-  
+
   #If using a sar archive for hana platform or hana client media, please provide compatible version of sapcar executable
   #sapcar_exe_file: '/sapmedia/SAPCAR'
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  5 15:30:40 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Fix how the HANA client options are handled. Now, if any of the
+  HANA client option variables are set, they will have preference
+  over the database option (the platform and extracted options) 
+
+-------------------------------------------------------------------
 Tue Jan 19 13:35:18 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.7.0


### PR DESCRIPTION
In some scenarios the hana client is not found properly. 
- HANA client and server SAR archives are already extracted in the sapmedia folder
- HANA database SAR is extracted and HANA client is in SAR format

To fix that I have done some preference changes. Now, if the `hana_client_archive_file` or `hana_client_software_path
` are present they will have preference over the database/platform options.

The change includes:
1. The HANA client is always extracted if the data is present. Before it was extracted only if the database was a SAR option
2. `hana_client_archive_file` or `hana_client_software_path
` have preference over other options

I have tested the next scenarios and everything worked fine:

Database as SAR - Client as SAR -> OK
Database as SAR - Client already extracted -> OK
Database already extracted - Client as SAR -> OK (before this was failing)
Database already extracted - Client already extracted -> OK (before this was failing)

The database can be in simple version (the patch option) or as platform, both work the same way.