### PR TITLE
Fix how sidadm user is transformed to lowercase in ha cluster states

### DIFF
--- a/hana/ha_cluster.sls
+++ b/hana/ha_cluster.sls
@@ -53,7 +53,7 @@ sudoers_backup_{{ sap_instance }}:
   file.copy:
     - name: {{ tmp_sudoers }}
     - source: {{ sudoers }}
-    - unless: cat {{ sudoers }} | grep {{ node.sid }}adm
+    - unless: cat {{ sudoers }} | grep {{ node.sid.lower() }}adm
     - require:
       - stop_hana_{{ sap_instance }}
 
@@ -61,7 +61,7 @@ sudoers_append_{{ sap_instance }}:
   file.append:
     - name: {{ tmp_sudoers }}
     - text: |
-        {{ node.sid }}adm ALL=(ALL) NOPASSWD: /usr/sbin/crm_attribute -n hana_{{ node.sid }}_site_srHook_*
+        {{ node.sid.lower() }}adm ALL=(ALL) NOPASSWD: /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_*
     - require:
       - sudoers_backup_{{ sap_instance }}
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 12 15:39:31 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Fix the HANA sidadm usage to tranfsorm to lowercase some states
+  managing the sudoers file in ha_cluster.sls state file 
+
+-------------------------------------------------------------------
 Fri Mar  5 15:30:40 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Fix how the HANA client options are handled. Now, if any of the


### PR DESCRIPTION
Related to: https://github.com/SUSE/shaptools/pull/65

Fix some sidadm conversions. If the provided sid is in uppercase the created states are incorrect, specifically the ones managing the `sudoers` entry content.

The rest of the uses of the sidadm are safe as they are treated in lower layers (`shaptools` specifically)

Some info: https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-CostOpt-12/#_allowing_sidadm_to_access_the_cluster

FYI: @petersatsuse