### PR TITLE
Set correct stickiness for the azure-lb resource

### DIFF
--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 28 14:26:18 UTC 2021 - Diego Akechi <dakechi@suse.com>
+
+- Set correct stickiness for the azure-lb resource
+  The azure-lb resource receives an stickiness=0 to not influence on
+  transitions calculations as the HANA resources have more priority
+
+-------------------------------------------------------------------
 Thu Mar 18 07:41:18 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Version bump 0.7.1

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -105,7 +105,8 @@ primitive rsc_ip_{{ sid }}_HDB{{ instance }} ocf:heartbeat:IPaddr2 \
 
 primitive rsc_socat_{{ sid }}_HDB{{ instance }} azure-lb \
     params port=625{{ instance }} \
-    op monitor timeout="20" interval="10" depth="0"
+    op monitor timeout="20" interval="10" depth="0" \
+    meta resource-stickiness=0
 
 group g_ip_{{ sid }}_HDB{{ instance }} rsc_ip_{{ sid }}_HDB{{ instance }} rsc_socat_{{ sid }}_HDB{{ instance }}
 


### PR DESCRIPTION
The azure-lb resource receives an stickiness=0 to not influence on
transitions calculations as the HANA resources have more priority.
Ref: https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources