### PR TITLE
prometheus-hanadb_exporter cluster primitiv adoption fix SUSE/ha-sap-terraform-deployments/#/686

### DIFF
--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -62,7 +62,7 @@ prometheus-hanadb_exporter:
 hanadb_exporter_configuration_{{ exporter_instance }}:
   file.managed:
     - source: salt://hana/templates/hanadb_exporter.j2
-    - name: /etc/hanadb_exporter/{{ exporter_instance }}.json
+    - name: /usr/etc/hanadb_exporter/{{ exporter_instance }}.json
     - template: jinja
     - require:
       - prometheus-hanadb_exporter

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -62,7 +62,7 @@ prometheus-hanadb_exporter:
 hanadb_exporter_configuration_{{ exporter_instance }}:
   file.managed:
     - source: salt://hana/templates/hanadb_exporter.j2
-    - name: /usr/etc/hanadb_exporter/{{ exporter_instance }}.json
+    - name: /etc/hanadb_exporter/{{ exporter_instance }}.json
     - template: jinja
     - require:
       - prometheus-hanadb_exporter

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -4,7 +4,6 @@ Fri May 07 07:15:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
 - Changing exporter stickiness to => 0 and adjusting the colocation 
   score from +inf to -inf and changing the colocation from Master to Slave. 
   This change fix the impact of a failed exporter in regards to the HANA DB.
-- changing path for hanadb_exporter_configuration as described in the documentation
 -------------------------------------------------------------------
 Wed Apr 28 14:26:18 UTC 2021 - Diego Akechi <dakechi@suse.com>
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Fri May 07 07:15:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
+Fri May 07 09:15:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
 
 - Changing exporter stickiness to => 0 and adjusting the colocation 
   score from +inf to -inf and changing the colocation from Master to Slave. 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,10 +1,10 @@
 -------------------------------------------------------------------
-Fri Apr 30 16:15:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
+Fri May 07 07:15:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
 
 - Changing exporter stickiness to => 0 and adjusting the colocation 
-  score from +inf to 1. This change fix the impact of a failed exporter
-  in regards to the HANA DB.
-
+  score from +inf to -inf and changing the colocation from Master to Slave. 
+  This change fix the impact of a failed exporter in regards to the HANA DB.
+- changing path for hanadb_exporter_configuration as described in the documentation
 -------------------------------------------------------------------
 Wed Apr 28 14:26:18 UTC 2021 - Diego Akechi <dakechi@suse.com>
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 30 16:15:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
+
+- Changing exporter stickiness to => 0 and adjusting the colocation 
+  score from +inf to 1. This change fix the impact of a failed exporter
+  in regards to the HANA DB.
+
+-------------------------------------------------------------------
 Wed Apr 28 14:26:18 UTC 2021 - Diego Akechi <dakechi@suse.com>
 
 - Set correct stickiness for the azure-lb resource

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -4,7 +4,8 @@ Fri May 07 09:15:21 UTC 2021 - Bernd Schubert <bschubert@suse.com>
 - Changing exporter stickiness to => 0 and adjusting the colocation 
   score from +inf to -inf and changing the colocation from Master to Slave. 
   This change fix the impact of a failed exporter in regards to the HANA DB.
-=======
+
+-------------------------------------------------------------------
 Thu May  6 08:49:19 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Change hanadb_exporter default timeout value to 30 seconds

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -270,8 +270,9 @@ primitive rsc_exporter_{{ sid }}_HDB{{ instance }} systemd:prometheus-hanadb_exp
     op start interval=0 timeout=100 \
     op stop interval=0 timeout=100 \
     op monitor interval=10 \
+    meta resource-stickiness=0 \
     meta target-role=Started
 
-colocation col_exporter_{{ sid }}_HDB{{ instance }} +inf: rsc_exporter_{{ sid }}_HDB{{ instance }}:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Master
+colocation col_exporter_{{ sid }}_HDB{{ instance }} 1: rsc_exporter_{{ sid }}_HDB{{ instance }}:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Master
 
 {%- endif %}

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -273,6 +273,6 @@ primitive rsc_exporter_{{ sid }}_HDB{{ instance }} systemd:prometheus-hanadb_exp
     meta resource-stickiness=0 \
     meta target-role=Started
 
-colocation col_exporter_{{ sid }}_HDB{{ instance }} 1: rsc_exporter_{{ sid }}_HDB{{ instance }}:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Master
+colocation col_exporter_{{ sid }}_HDB{{ instance }} -inf: rsc_exporter_{{ sid }}_HDB{{ instance }}:Started msl_SAPHana_{{ sid }}_HDB{{ instance }}:Slave
 
 {%- endif %}


### PR DESCRIPTION
prometheus-hanadb_exporter cluster primitiv adoption, the fix will address this issue:
https://github.com/SUSE/ha-sap-terraform-deployments/issues/686
The change is needed to avoid a HANA DB takeover just in case that the local hanadb_exporter has an issue and is not able to start.