### PR TITLE
Change hanadb_exporter start timeout value to 30s

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -18,7 +18,7 @@ hana:
     $help: The path to already extracted HANA platform installation media folder which can be local or already mounted shared location (NFS, SMB, etc). This will have preference over hana installation media archive
     $optional: true
   use_hana_archive_file:
-    $name: Use archive file for HANA platform installation 
+    $name: Use archive file for HANA platform installation
     $type: boolean
     $default: false
     $help: Mark this option if you want to use a hana archive file for the HANA installation
@@ -142,7 +142,7 @@ hana:
           $name: Path to XML file with HANA Passwords
           $visibleIf: .use_hdb_pwd_file == true
           $type: text
-          $help: Path to the XML file location. The password template can be generated with the hdblcm --dump_configfile_template option        
+          $help: Path to the XML file location. The password template can be generated with the hdblcm --dump_configfile_template option
         sapadm_password:
           $name: SAP admin password (<sid>adm)
           $visibleIf: .use_config_file == false
@@ -317,6 +317,6 @@ hana:
         timeout:
           $name: Connection timeout
           $type: text
-          $default: 600
+          $default: 30
           $optional: true
           $help: Timeout in seconds for HANA database connection

--- a/hana/monitoring.sls
+++ b/hana/monitoring.sls
@@ -83,9 +83,8 @@ hanadb_exporter_service_{{ exporter_instance }}:
   service.{{ service_status }}:
     - name: prometheus-hanadb_exporter@{{ exporter_instance }}
     - enable: {{ service_enabled }}
-    - reload: True
-    - require:
-        - hanadb_exporter_configuration_{{ exporter_instance }}
+    - watch:
+      - file: hanadb_exporter_configuration_{{ exporter_instance }}
 
 {% endif %}
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -82,7 +82,7 @@ hana:
         user: 'SYSTEM'
         password: 'Qwerty1234'
         #port: 30015 # HANA database port. If multi_tenant is set this value is 3XX13 by default where XX is the instance number
-        timeout: 600 # Timeout in seconds to start the connection with HANA database
+        timeout: 30 # Timeout in seconds to start the connection with HANA database
 
     - host: 'hana02'
       sid: 'prd'

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May  6 08:49:19 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Change hanadb_exporter default timeout value to 30 seconds
+
+-------------------------------------------------------------------
 Wed Apr 28 14:26:18 UTC 2021 - Diego Akechi <dakechi@suse.com>
 
 - Set correct stickiness for the azure-lb resource

--- a/templates/hanadb_exporter.j2
+++ b/templates/hanadb_exporter.j2
@@ -2,7 +2,7 @@
 {
   "exposition_port": {{ exporter.exposition_port|default(9668) }},
   "multi_tenant": {{ exporter.multi_tenant|default(true)|tojson }},
-  "timeout": {{exporter.timeout|default(600)}},
+  "timeout": {{exporter.timeout|default(30)}},
   "hana": {
     "host": "{{ grains['host'] }}",
     {%- if exporter.multi_tenant|default(true) and exporter.port is not defined %}


### PR DESCRIPTION
Simple change to reduce the hanadb_exporter start timeout to 30 seconds
(And it took advantage of fixing one of the states involved in the exporter initialization)