### PR TITLE
Document extra_parameters in pillar.example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -58,6 +58,12 @@ hana:
         # Or specify HANA system & sapadm users' passwords like below
         system_user_password: 'Qwerty1234'
         sapadm_password: 'Qwerty1234'
+        # You can also provide additional hana configuration parameters as done in the following example
+        # See https://help.sap.com/viewer/2c1988d620e04368aa4103bf26f17727/2.0.00/en-US/c16432a77b6144dcb75aace2b4fcacff.html
+        # for details on all the supported parameters
+        extra_parameters:
+          # As an example, this parameter allows to ignore some prerequisite tests
+          ignore: check_min_mem
       primary:
         name: NUREMBERG
         userkey:

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu May  6 16:19:45 UTC 2021 - Rubén Torrero Marijnissen <rtorreromarijnissen@suse.com>
+
+- Document extra_parameters in pillar.example (bsc#1185643)
+
+-------------------------------------------------------------------
 Thu May  6 08:49:19 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
 
 - Change hanadb_exporter default timeout value to 30 seconds


### PR DESCRIPTION
This PR adds a brief example on the pillar.example that allows to set additional parameters for hana installations. For details on which parameters can be added, check -> https://help.sap.com/viewer/2c1988d620e04368aa4103bf26f17727/2.0.00/en-US/c16432a77b6144dcb75aace2b4fcacff.html