### PR TITLE
add native fencing for microsoft-azure - follow up

### DIFF
--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -48,7 +48,7 @@ property $id="cib-bootstrap-options" \
     concurrent-fencing=true
 
 primitive rsc_azure_stonith_{{ sid }}_HDB{{ instance }} stonith:fence_azure_arm \
-    params subscriptionId={{ grains['subscription_id'] }} resourceGroup={{ grains['resource_group_name'] }} tenantId={{ grains['tenant_id'] }} login={{ grains['fence_agent_app_id'] }} passwd="{{ grains['fence_agent_client_secret'] }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
+    params subscriptionId={{ data.azure_subscription_id }} resourceGroup={{ data.azure_resource_group_name }} tenantId={{ data.azure_tenant_id }} login={{ data.azure_fence_agent_app_id }} passwd="{{ data.azure_fence_agent_client_secret }}" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 \
     op monitor interval=3600 timeout=120 \
     meta target-role=Started
 

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -4,6 +4,8 @@
 {%- set cloud_provider = grains['cloud_provider'] %}
 {%- set monitoring_enabled = pillar.cluster.monitoring_enabled|default(False) %}
 
+{%- set native_fencing = data.native_fencing|default(False) %}
+
 {%- if cloud_provider == "amazon-web-services" %}
 {%- set native_fencing = data.native_fencing|default(True) %}
 {%- elif cloud_provider == "google-cloud-platform" %}

--- a/templates/scale_up_resources.j2
+++ b/templates/scale_up_resources.j2
@@ -4,14 +4,14 @@
 {%- set cloud_provider = grains['cloud_provider'] %}
 {%- set monitoring_enabled = pillar.cluster.monitoring_enabled|default(False) %}
 
-{%- set native_fencing = data.native_fencing|default(False) %}
-
 {%- if cloud_provider == "amazon-web-services" %}
 {%- set native_fencing = data.native_fencing|default(True) %}
 {%- elif cloud_provider == "google-cloud-platform" %}
 {%- set native_fencing = data.native_fencing|default(True) %}
 {%- set vip_mechanism = data.virtual_ip_mechanism|default("load-balancer") %}
 {%- elif cloud_provider == "microsoft-azure" %}
+{%- set native_fencing = data.native_fencing|default(False) %}
+{%- else %}{# all other cases like openstack and libvirt #}
 {%- set native_fencing = data.native_fencing|default(False) %}
 {%- endif %}
 


### PR DESCRIPTION
This is a follow up for #130 which uses pillars set in `habootstrap-formula` instead of grains.

This adds the needed resources to implement native fencing on azure.

It also defines for all cloud providers the same defaults to use native fencing as https://github.com/SUSE/ha-sap-terraform-deployments/.
```
# ha-sap-terraform-deployments
grep -A5 hana_cluster_fencing_mechanism */variables.tf | grep 'variable |default'
  1:openstack/variables.tf:variable "hana_cluster_fencing_mechanism" {
  4:openstack/variables.tf-  default     = "sbd"
  8:libvirt/variables.tf:variable "hana_cluster_fencing_mechanism" {
  11:libvirt/variables.tf-  default     = "sbd"
  21:gcp/variables.tf:variable "hana_cluster_fencing_mechanism" {
  24:gcp/variables.tf-  default     = "native"
  34:azure/variables.tf:variable "hana_cluster_fencing_mechanism" {
  37:azure/variables.tf-  default     = "sbd"
  47:aws/variables.tf:variable "hana_cluster_fencing_mechanism" {
  50:aws/variables.tf-  default     = "native"
```

```
# this formula
{%- if cloud_provider == "amazon-web-services" %}
{%- set native_fencing = data.native_fencing|default(True) %}
{%- elif cloud_provider == "google-cloud-platform" %}
{%- set native_fencing = data.native_fencing|default(True) %}
{%- elif cloud_provider == "microsoft-azure" %}
{%- set native_fencing = data.native_fencing|default(False) %}
{%- endif %}

```