### PR TITLE
use multi-target Hook on HANA scale-out and use sudoers.d file

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.8.0+git.%ct.%h</param>
+    <param name="versionformat">0.8.1+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 11 15:08:11 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.8.1
+  * use multi-target Hook on HANA scale-out
+
+-------------------------------------------------------------------
 Thu Jul 29 13:21:45 UTC 2021 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.8.0


### PR DESCRIPTION
Starting with version 0.180 the SAPHanaSR-ScaleOut package supports SAP HANA scale-out multi-target system replication. That means you can connect a third HANA site by system replication to either of the two HANA sites which are managed by the SUSE HA cluster.

More Details can be found here:
https://www.suse.com/c/sap-hana-scale-out-upgrade-details/
https://www.suse.com/c/sap-hana-scale-out-multi-target-upgrade/

To enable this feature, a different hook script needs to be used:
~~/usr/share/SAPHanaSR-ScaleOut/SAPHanaSR.py~~
/usr/share/SAPHanaSR-ScaleOut/SAPHanaSrMultiTarget.py

This PR enables the new Hook if it is available and also migrates old setups (hook and sudoers).

fixes https://github.com/SUSE/saphanabootstrap-formula/issues/135 
fixes https://github.com/SUSE/ha-sap-terraform-deployments/issues/787