### PR TITLE
fixes for SAPHanaSR hook and Majority Maker

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.10.0+git.%ct.%h</param>
+    <param name="versionformat">0.10.1+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/hana/ha_cluster.sls
+++ b/hana/ha_cluster.sls
@@ -125,9 +125,8 @@ remove_wrong_ha_hook_{{ sap_instance }}_sections_multi_target:
         ha_dr_provider_SAPHanaSR:
     - require:
       - pkg: install_SAPHanaSR
-    - unless:
-      - fun: file.file_exists
-        path: sr_hook_multi_target
+    - onlyif:
+      - test -f {{ sr_hook_multi_target }}
 
 remove_wrong_ha_hook_{{ sap_instance }}_options_multi_target:
   ini.options_absent:
@@ -161,9 +160,8 @@ remove_wrong_ha_hook_{{ sap_instance }}_options:
           - ha_dr_saphanasrmultitarget
     - require:
       - pkg: install_SAPHanaSR
-    - onlyif:
-      - fun: file.file_exists
-        path: sr_hook_multi_target
+    - unless:
+      - test -f {{ sr_hook_multi_target }}
 
 # Configure system replication operation mode in the primary site
 {% for secondary_node in hana.nodes if node.primary is defined and secondary_node.secondary is defined and secondary_node.secondary.remote_host == host %}

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 06 18:31:32 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.10.1
+  * fix hook removal conditions
+  * fix majority_maker code on case grain is empty
+
+-------------------------------------------------------------------
 Thu May 13 08:16:24 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.10.0

--- a/templates/cluster_resources.j2
+++ b/templates/cluster_resources.j2
@@ -273,7 +273,7 @@ colocation col_exporter_{{ sid }}_HDB{{ instance }} -inf: rsc_exporter_{{ sid }}
 
 {%- endif %}
 
-{%- if majority_maker != "" and majority_maker != "None" %}
+{%- if majority_maker != "" and majority_maker != None and majority_maker != "None" %}
 ######################################
 # majority maker
 ######################################


### PR DESCRIPTION
-  25b031d60d9a76b68c568e5a5585c4a18af25985 fixes the updated SAPHanaSR hook code introduced in #136 to not remove the hook again.
- 543ed4fd3ed3584047ee42d1763e02d4e70ea924 adds `None` as a condition not to deploy majority maker constraints. This will be the case if the pillar/grain is not set or empty.