### PR TITLE
make sudoers rules more secure

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.10.1+git.%ct.%h</param>
+    <param name="versionformat">0.11.0+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/hana/ha_cluster.sls
+++ b/hana/ha_cluster.sls
@@ -5,7 +5,7 @@
 {% set sr_hook_path = '/usr/share/SAPHanaSR-ScaleOut' %}
 {% set sr_hook_multi_target = sr_hook_path + '/SAPHanaSrMultiTarget.py' %}
 {% set sr_hook = sr_hook_path + '/SAPHanaSR.py' %}
-{% set sr_hook_gen = salt['cmd.run']('grep "^srHookGen = " "'~sr_hook~'" | cut -d\'"\' -f2', python_shell=true) %}
+
 remove_SAPHanaSR:
   pkg.removed:
     - pkgs:
@@ -22,7 +22,7 @@ install_SAPHanaSR:
 {% set sr_hook_path = '/usr/share/SAPHanaSR' %}
 {% set sr_hook_multi_target = sr_hook_path + '/SAPHanaSrMultiTarget.py' %}
 {% set sr_hook = sr_hook_path + '/SAPHanaSR.py' %}
-{% set sr_hook_gen = salt['cmd.run']('grep "^srHookGen = " "'~sr_hook~'" | cut -d\'"\' -f2', python_shell=true) %}
+
 remove_SAPHanaSR:
   pkg.removed:
     - pkgs:
@@ -56,37 +56,21 @@ install_SAPHanaSR:
 
 sudoers_create_{{ sap_instance }}:
   file.managed:
+    - source: salt://hana/templates/ha_cluster_sudoers.j2
     - name: {{ sudoers }}
+    - template: jinja
     - user: root
     - group: root
     - mode: 0440
-    - contents: |
-        {%- if hana.scale_out %}
-        # SAPHanaSR-ScaleOut needs for {{ sr_hook_multi_target }}
-        Cmnd_Alias GSH_QUERY      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_gsh -G
-        Cmnd_Alias GSH_UPDATE     = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_gsh -v {{ sr_hook_gen }} -l reboot
-        # be compatible with non-multi-target mode
-        Cmnd_Alias SOK_GLOB       = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_srHook -v SOK -t crm_config -s SAPHanaSR
-        Cmnd_Alias SFAIL_GLOB     = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_srHook -v SFAIL -t crm_config -s SAPHanaSR
-        # be compatible with multi-target mode
-        Cmnd_Alias SOK_GLOB_MTS   = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_mts -v SOK -t crm_config -s SAPHanaSR
-        Cmnd_Alias SFAIL_GLOB_MTS = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_mts -v SFAIL -t crm_config -s SAPHanaSR
-        Cmnd_Alias SOK_SITEA      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SOK   -t crm_config -s SAPHanaSR
-        Cmnd_Alias SFAIL_SITEA    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SFAIL -t crm_config -s SAPHanaSR
-        Cmnd_Alias SOK_SITEB      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SOK   -t crm_config -s SAPHanaSR
-        Cmnd_Alias SFAIL_SITEB    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SFAIL -t crm_config -s SAPHanaSR
-        {{ node.sid.lower() }}adm ALL=(ALL) NOPASSWD: GSH_QUERY, GSH_UPDATE, SOK_GLOB, SFAIL_GLOB, SOK_GLOB_MTS, SFAIL_GLOB_MTS, SOK_SITEA, SFAIL_SITEA, SOK_SITEB, SFAIL_SITEB
-        {%- else %}
-        # SAPHanaSR needs for {{ sr_hook }}
-        Cmnd_Alias SOK_SITEA      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SOK   -t crm_config -s SAPHanaSR
-        Cmnd_Alias SFAIL_SITEA    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SFAIL -t crm_config -s SAPHanaSR
-        Cmnd_Alias SOK_SITEB      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SOK   -t crm_config -s SAPHanaSR
-        Cmnd_Alias SFAIL_SITEB    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SFAIL -t crm_config -s SAPHanaSR
-        {{ node.sid.lower() }}adm ALL=(ALL) NOPASSWD: SOK_SITEA, SFAIL_SITEA, SOK_SITEB, SFAIL_SITEB
-        {%- endif %}
     - check_cmd: /usr/sbin/visudo -c -f
     - require:
       - pkg: install_SAPHanaSR
+    - context:
+        node: {{ node }}
+        sites: {{ sites }}
+        sr_hook: {{ sr_hook }}
+        sr_hook_multi_target: {{ sr_hook_multi_target }}
+        sr_hook_string: __slot__:salt:file.grep({{ sr_hook }}, "^srHookGen = ").stdout
 
 # remove old entries from /etc/sudoers (migration to new /etc/sudoers.d/SAPHanaSR file)
 sudoers_remove_old_entries_{{ sap_instance }}_srHook:

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jul 19 11:47:52 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.11.0
+  * use check_cmd instead of tmp sudoers file
+  * make sudoers rules more secure
+  * migrate sudoers to template file
+
+-------------------------------------------------------------------
 Thu Jun 06 18:31:32 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.10.1

--- a/templates/ha_cluster_sudoers.j2
+++ b/templates/ha_cluster_sudoers.j2
@@ -1,0 +1,24 @@
+{%- from "hana/map.jinja" import hana with context -%}
+{%- if hana.scale_out -%}
+# SAPHanaSR-ScaleOut needs for {{ sr_hook_multi_target }}
+Cmnd_Alias GSH_QUERY      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_gsh -G
+Cmnd_Alias GSH_UPDATE     = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_gsh -v {{ sr_hook_string.split('"')[1]|default("1.0") }} -l reboot
+# be compatible with non-multi-target mode
+Cmnd_Alias SOK_GLOB       = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_srHook -v SOK -t crm_config -s SAPHanaSR
+Cmnd_Alias SFAIL_GLOB     = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_srHook -v SFAIL -t crm_config -s SAPHanaSR
+# be compatible with multi-target mode
+Cmnd_Alias SOK_GLOB_MTS   = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_mts -v SOK -t crm_config -s SAPHanaSR
+Cmnd_Alias SFAIL_GLOB_MTS = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_glob_mts -v SFAIL -t crm_config -s SAPHanaSR
+Cmnd_Alias SOK_SITEA      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SOK   -t crm_config -s SAPHanaSR
+Cmnd_Alias SFAIL_SITEA    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SFAIL -t crm_config -s SAPHanaSR
+Cmnd_Alias SOK_SITEB      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SOK   -t crm_config -s SAPHanaSR
+Cmnd_Alias SFAIL_SITEB    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SFAIL -t crm_config -s SAPHanaSR
+{{ node.sid.lower() }}adm ALL=(ALL) NOPASSWD: GSH_QUERY, GSH_UPDATE, SOK_GLOB, SFAIL_GLOB, SOK_GLOB_MTS, SFAIL_GLOB_MTS, SOK_SITEA, SFAIL_SITEA, SOK_SITEB, SFAIL_SITEB
+{%- else %}
+# SAPHanaSR needs for {{ sr_hook }}
+Cmnd_Alias SOK_SITEA      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SOK   -t crm_config -s SAPHanaSR
+Cmnd_Alias SFAIL_SITEA    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['a'] }} -v SFAIL -t crm_config -s SAPHanaSR
+Cmnd_Alias SOK_SITEB      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SOK   -t crm_config -s SAPHanaSR
+Cmnd_Alias SFAIL_SITEB    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SFAIL -t crm_config -s SAPHanaSR
+{{ node.sid.lower() }}adm ALL=(ALL) NOPASSWD: SOK_SITEA, SFAIL_SITEA, SOK_SITEB, SFAIL_SITEB
+{%- endif %}


### PR DESCRIPTION
This PR tackles https://bugzilla.suse.com/show_bug.cgi?id=1196642 which suggests:
- to get rid of the temporary unsecure sudoers file in `/tmp/` 
- do not use `*` in suders rules

The outcome of a discussion with the owners of https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-scaleOut-PerfOpt-15/index.html was, that it is OK to go this way (getting rid of `*`). The best practices have to be seen as a general guideline and might or might not suggest security best practices.

In addition to the changes named above, it introduces a template file for the SAPHanaSR sudoers. This way the templating is done in the template instead of the state and we can pass a [salt slot](https://docs.saltproject.io/en/latest/topics/slots/index.html) to evaluate the "srHookGen" at a very late stage (after the rpm dependencies are met).

Test deployments on azure and gcp and on scale-up and scale-out deployments have been successfully done.
A test package build is available here: https://build.opensuse.org/package/show/home:waldt:branches:network:ha-clustering:sap-deployments:devel/saphanabootstrap-formula