### PR TITLE
add SAPHanaSR takeover blocker

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.11.0+git.%ct.%h</param>
+    <param name="versionformat">0.12.0+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 28 10:03:12 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
+
+- Version bump 0.12.0
+  * add SAPHanaSR takeover blocker
+
+-------------------------------------------------------------------
 Thu Jul 19 11:47:52 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.11.0

--- a/templates/ha_cluster_sudoers.j2
+++ b/templates/ha_cluster_sudoers.j2
@@ -22,3 +22,6 @@ Cmnd_Alias SOK_SITEB      = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() 
 Cmnd_Alias SFAIL_SITEB    = /usr/sbin/crm_attribute -n hana_{{ node.sid.lower() }}_site_srHook_{{ sites['b'] }} -v SFAIL -t crm_config -s SAPHanaSR
 {{ node.sid.lower() }}adm ALL=(ALL) NOPASSWD: SOK_SITEA, SFAIL_SITEA, SOK_SITEB, SFAIL_SITEB
 {%- endif %}
+# SAPHanaSR takeover blocker needs for {{ sustkover_hook }}
+Cmnd_Alias HOOK_HELPER_TKOVER = /usr/sbin/SAPHanaSR-hookHelper --case checkTakeover --sid={{ node.sid.lower() }}
+{{ node.sid.lower() }}adm ALL=(ALL) NOPASSWD: HOOK_HELPER_TKOVER


### PR DESCRIPTION
This adds the "SAPHanaSR takeover blocker" feature described in https://www.suse.com/c/sap-hana-cockpit-with-suse-ha-integration-greatly-improves-data-integrity/

It is available for SAP HANA Scale Up deployments.

- adds new `susTkOver.py` hook to `global.ini` if script is found
- add new sudo rule for `SAPHanaSR-hookHelper` which is called by `susTkOver.py` (always added)

Fixes #143 