### PR TITLE
revert spec file changes

### DIFF
--- a/_service
+++ b/_service
@@ -4,7 +4,7 @@
     <param name="scm">git</param>
     <param name="exclude">.git</param>
     <param name="filename">saphanabootstrap-formula</param>
-    <param name="versionformat">0.13.0+git.%ct.%h</param>
+    <param name="versionformat">0.13.1+git.%ct.%h</param>
     <param name="revision">%%VERSION%%</param>
   </service>
 

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Friday Dec 04 11:27:52 UTC 2022 - Steve Stringer <steven.stringer@suse.com>
+Friday Nov 04 14:25:52 UTC 2022 - Steve Stringer <steven.stringer@suse.com>
 
 - Version bump 0.13.1
   * revert changes to spec file to re-enable SLES RPM builds

--- a/saphanabootstrap-formula.changes
+++ b/saphanabootstrap-formula.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Friday Dec 04 11:27:52 UTC 2022 - Steve Stringer <steven.stringer@suse.com>
+
+- Version bump 0.13.1
+  * revert changes to spec file to re-enable SLES RPM builds
+  
+-------------------------------------------------------------------
 Mon Aug 15 08:29:52 UTC 2022 - Eike Waldt <waldt@b1-systems.de>
 
 - Version bump 0.13.0

--- a/saphanabootstrap-formula.spec
+++ b/saphanabootstrap-formula.spec
@@ -39,6 +39,7 @@ Suggests:       prometheus-hanadb_exporter >= 0.7.0
 
 %define fname hana
 %define fdir  %{_datadir}/salt-formulas
+%define ftemplates templates
 
 %description
 SAP HANA deployment salt formula. This formula is capable to install
@@ -81,6 +82,7 @@ fi
 %dir %attr(0755, root, salt) %{fdir}/metadata
 
 %attr(0755, root, salt) %{fdir}/states/%{fname}
+%attr(0755, root, salt) %{fdir}/states/%{fname}/%{ftemplates}
 %attr(0755, root, salt) %{fdir}/metadata/%{fname}
 
 %changelog


### PR DESCRIPTION
A previous change to the spec file prevented the build of RPMs for SLES.  This change has been reverted.