### PR TITLE
fixed CI following branch name change

### DIFF
--- a/.github/workflows/formulaCI.yml
+++ b/.github/workflows/formulaCI.yml
@@ -180,7 +180,7 @@ jobs:
   submit:
     needs: [tab, codespell, shellcheck, yamllint, jsonlint, mlc, salt, delivery]
     runs-on: ubuntu-20.04
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     container:
       image: shap/continuous_deliver
       env:


### PR DESCRIPTION
The branch 'master' was renamed 'main' earlier in the year.  When this change was made, the github workflow was not updated.  This change updates the workflow to reflect the branch name change and ensures that new releases automatically submitted to OBS.