### PR TITLE
Add workaround to make "shaptools" available within Salt Bundle (bsc#1212695)

### DIFF
--- a/hana/packages.sls
+++ b/hana/packages.sls
@@ -42,13 +42,11 @@ python3-shaptools:
     - resolve_capabilities: true
 
 {# If venv-salt-minion is installed, then we make shaptools available on this environment #}
-{% if salt['pkg.version']('venv-salt-minion') %}
+{% if salt['pkg.version']('venv-salt-minion') and salt['file.file_exists']("/usr/bin/python3") %}
+{% set python_site_packages_path = salt["cmd.run"]("/usr/bin/python3 -c \"import sysconfig as s; print(s.get_paths().get('purelib'))\"") %}
+{% set salt_bundle_site_packages_path = salt["cmd.run"]("/usr/lib/venv-salt-minion/bin/python -c \"import sysconfig as s; print(s.get_paths().get('purelib'))\"") %}
 shaptools_available_in_salt_bundle:
   file.symlink:
-    - name: /usr/lib/venv-salt-minion/lib/python3.10/site-packages/shaptools
-    - target: /usr/lib/python3.6/site-packages/shaptools/
-    - onlyif:
-      - test -d /usr/lib/python3.6/site-packages/shaptools/
-      - test -d /usr/lib/venv-salt-minion/lib/python3.10/site-packages/
-      - test ! -e /usr/lib/venv-salt-minion/lib/python3.10/site-packages/shaptools/
+    - name: {{ salt_bundle_site_packages_path }}/shaptools
+    - target: {{ python_site_packages_path }}/shaptools/
 {% endif %}

--- a/hana/packages.sls
+++ b/hana/packages.sls
@@ -40,3 +40,15 @@ python3-shaptools:
         attempts: 3
         interval: 15
     - resolve_capabilities: true
+
+{# If venv-salt-minion is installed, then we make shaptools available on this environment #}
+{% if salt['pkg.version']('venv-salt-minion') %}
+shaptools_available_in_salt_bundle:
+  file.symlink:
+    - name: /usr/lib/venv-salt-minion/lib/python3.10/site-packages/shaptools
+    - target: /usr/lib/python3.6/site-packages/shaptools/
+    - onlyif:
+      - test -d /usr/lib/python3.6/site-packages/shaptools/
+      - test -d /usr/lib/venv-salt-minion/lib/python3.10/site-packages/
+      - test ! -e /usr/lib/venv-salt-minion/lib/python3.10/site-packages/shaptools/
+{% endif %}


### PR DESCRIPTION
This PR simply introduces an small hack to the formula to make "shaptools" available inside current Salt Bundle environment, that is used for registered system in SUSE Manager.

The current extending mechanism for Salt Bundle doesn't make it easy to extend it with "shaptools" coming from an RPM package, so we did this small hack that works fine when using the current Salt Bundle.

Once we have a better mechanism for extending the Salt Bundle, then we should get rid of this workaround and go in favor of the new solution.

Tracks: https://github.com/SUSE/spacewalk/issues/21907